### PR TITLE
[reboot] Remove exec from the platform_reboot call when run in kdump capture kernel

### DIFF
--- a/scripts/reboot
+++ b/scripts/reboot
@@ -14,7 +14,7 @@ if [ -e $VMCORE_FILE -a -s $VMCORE_FILE ]; then
         sync
         PLATFORM=$(grep -oP 'sonic_platform=\K\S+' /proc/cmdline)
         if [ ! -z "${PLATFORM}" -a -x ${DEVPATH}/${PLATFORM}/${PLAT_REBOOT} ]; then
-            exec ${DEVPATH}/${PLATFORM}/${PLAT_REBOOT}
+            ${DEVPATH}/${PLATFORM}/${PLAT_REBOOT}
         fi
         # If no platform-specific reboot tool, just run /sbin/reboot
         /sbin/reboot


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Modify the reboot script not to use 'exec' when performing platform_reboot function call to avoid hang issue during reboot.
Like AS9726-32D/AS9736-64D, it will hang when capture kernel tried to stop sonic platform related service.

