### PR TITLE
[CLI] Fix the error of running "show storm-control interface"

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -472,6 +472,7 @@ def storm_control(ctx, namespace, display):
             click.echo(tabulate(body, header, tablefmt="grid"))
 
 @storm_control.command('interface')
+@multi_asic_util.multi_asic_click_options
 @click.argument('interface', metavar='<interface>',required=True)
 def interface(interface, namespace, display):
     if multi_asic.is_multi_asic() and namespace not in multi_asic.get_namespace_list():


### PR DESCRIPTION
#### What I did
CLI shows an error when trying to show the storm control configuration. 
This PR is to fix the error of running "show storm-control interface".

#### Previous command output (if the output of a command-line utility has changed)
```shell
admin@sonic:~$ show storm-control interface Ethernet0
Traceback (most recent call last):
  File "/usr/local/bin/show", line 8, in <module>
    sys.exit(cli())
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
TypeError: interface() missing 2 required positional arguments: 'namespace' and 'display'
```
#### New command output (if the output of a command-line utility has changed)
```shell
admin@sonic:~$ show storm-control interface Ethernet0
+------------------+--------------+---------------+---------------------+
| Interface Name   | Storm Type   |   Rate (kbps) | Burst Size(kbits)   |
+==================+==============+===============+=====================+
| Ethernet0        | broadcast    |         10000 | default             |
+------------------+--------------+---------------+---------------------+
```
