### PR TITLE
Not allow set lt at rj45 port

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -4351,6 +4351,7 @@ def add(ctx, interface_name, ip_addr, gw):
             config_db.set_entry("MGMT_INTERFACE", (interface_name, str(ip_address)), {"NULL": "NULL"})
         else:
             config_db.set_entry("MGMT_INTERFACE", (interface_name, str(ip_address)), {"gwaddr": gw})
+        config_db.set_entry("MGMT_PORT", interface_name, {"admin_status": "up", "alias": interface_name})
 
         return
 

--- a/scripts/portconfig
+++ b/scripts/portconfig
@@ -160,6 +160,10 @@ class portconfig(object):
         if self.is_lag:
             raise Exception("Invalid port %s" % (port))
 
+        if self.is_rj45_port:
+            print("Setting RJ45 ports' link-training is not supported")
+            exit(1)
+
         if self.verbose:
             print("Setting link-training %s on port %s" % (mode, port))
         lt_modes = ['on', 'off']

--- a/show/main.py
+++ b/show/main.py
@@ -457,6 +457,7 @@ def storm_control(ctx, namespace, display):
             click.echo(tabulate(body, header, tablefmt="grid"))
 
 @storm_control.command('interface')
+@multi_asic_util.multi_asic_click_options
 @click.argument('interface', metavar='<interface>',required=True)
 def interface(interface, namespace, display):
     if multi_asic.is_multi_asic() and namespace not in multi_asic.get_namespace_list():

--- a/tests/config_lt_test.py
+++ b/tests/config_lt_test.py
@@ -38,6 +38,11 @@ class TestConfigInterface(object):
         result = self.basic_check("link-training", ["PortChannel0001", "on"], ctx, operator.ne)
         assert 'Invalid port PortChannel0001' in result.output
 
+        result = self.basic_check("link-training", ["Ethernet16", "on"], ctx, operator.ne)
+        assert "Setting RJ45 ports' link-training is not supported" in result.output
+        result = self.basic_check("link-training", ["Ethernet16", "off"], ctx, operator.ne)
+        assert "Setting RJ45 ports' link-training is not supported" in result.output
+
     def basic_check(self, command_name, para_list, ctx, op=operator.eq, expect_result=0):
         runner = CliRunner()
         result = runner.invoke(config.config.commands["interface"].commands[command_name], para_list, obj = ctx)


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Skip setting link-training on RJ-45 interfaces
#### How I did it
Check the interface type. If the interface is RJ-45, just return error.
#### How to verify it
Enable link-training or disable link-training on RJ45 interfaces, error message shall be shown.
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

