### PR TITLE
When enabling mgmtvrf, NTP vrf needs to be configured as "mgmt"

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -528,7 +528,10 @@ def address ():
     mgmt_ip_data = config_db.get_table('MGMT_INTERFACE')
     for key in natsorted(list(mgmt_ip_data.keys())):
         click.echo("Management IP address = {0}".format(key[1]))
-        click.echo("Management Network Default Gateway = {0}".format(mgmt_ip_data[key]['gwaddr']))
+        if mgmt_ip_data[key].get('gwaddr') is not None:
+            click.echo("Management Network Default Gateway = {0}".format(mgmt_ip_data[key]['gwaddr']))
+        else:
+            click.echo("Management Network Default Gateway = ")
 
 #
 # 'snmpagentaddress' group ("show snmpagentaddress ...")


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
[#15058](https://github.com/sonic-net/sonic-buildimage/pull/15058) 
Configure NTP global parameters, and specify the NTP vrf as "default". 
The NTP vrf does not change to "mgmt" when mgmtvrf is enabled, causing NTP create socket to fail.
```
ERR ntpd[34933]: bind(22) AF_INET 10.250.0.181#123 flags 0x19 failed: Cannot assign requested address
ERR ntpd[34933]: unable to create socket on eth0 (5) for 10.250.0.181#123
```
When mgmtvrf is enabled, the NTP vrf should be changed to "mgmt".

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

