### PR TITLE
Reject to delete portchannel unless subport interface has been deleted first

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -4351,6 +4351,7 @@ def add(ctx, interface_name, ip_addr, gw):
             config_db.set_entry("MGMT_INTERFACE", (interface_name, str(ip_address)), {"NULL": "NULL"})
         else:
             config_db.set_entry("MGMT_INTERFACE", (interface_name, str(ip_address)), {"gwaddr": gw})
+        config_db.set_entry("MGMT_PORT", interface_name, {"admin_status": "up", "alias": interface_name})
 
         return
 

--- a/config/main.py
+++ b/config/main.py
@@ -2126,7 +2126,7 @@ def add_portchannel(ctx, portchannel_name, min_links, fallback, fast_rate):
 @click.pass_context
 def remove_portchannel(ctx, portchannel_name):
     """Remove port channel"""
-    
+
     db = ValidatedConfigDBConnector(ctx.obj['db'])
     if ADHOC_VALIDATION:
         if is_portchannel_name_valid(portchannel_name) != True:
@@ -2136,6 +2136,10 @@ def remove_portchannel(ctx, portchannel_name):
         # Don't proceed if the port channel does not exist
         if is_portchannel_present_in_db(db, portchannel_name) is False:
             ctx.fail("{} is not present.".format(portchannel_name))
+
+        subport = interface_has_subport(db, portchannel_name)
+        if len(subport):
+            ctx.fail("{} contains a subport interface. Remove subport interface first".format(portchannel_name))
 
         # Dont let to remove port channel if vlan membership exists
         for k,v in db.get_table('VLAN_MEMBER'): # TODO: MISSING CONSTRAINT IN YANG MODEL

--- a/show/main.py
+++ b/show/main.py
@@ -457,6 +457,7 @@ def storm_control(ctx, namespace, display):
             click.echo(tabulate(body, header, tablefmt="grid"))
 
 @storm_control.command('interface')
+@multi_asic_util.multi_asic_click_options
 @click.argument('interface', metavar='<interface>',required=True)
 def interface(interface, namespace, display):
     if multi_asic.is_multi_asic() and namespace not in multi_asic.get_namespace_list():


### PR DESCRIPTION
Reject to delete portchannel unless subport interface has been deleted first

This will avoid leaving the subport info in redis db and chip.

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->


