### PR TITLE
Ignore error for "ip neigh flush" because interface has been removed

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -4631,7 +4631,8 @@ def remove(ctx, interface_name, ip_addr):
         command = ['sudo', 'ip', 'netns', 'exec', str(ctx.obj['namespace']), 'ip', 'neigh', 'flush', 'dev', str(interface_name), str(ip_address)]
     else:
         command = ['ip', 'neigh', 'flush', 'dev', str(interface_name), str(ip_address)]
-    clicommon.run_command(command)
+    # Manually flush deprecated neighbors, and ignore error because the interface might have been removed in some rare circumstances
+    clicommon.run_command(command, ignore_error = True)
 
 #
 # 'loopback-action' subcommand

--- a/tests/ip_config_test.py
+++ b/tests/ip_config_test.py
@@ -43,7 +43,8 @@ class TestConfigIP(object):
     def mock_run_bgp_command():
         return ""
 
-    def test_add_del_interface_valid_ipv4(self):
+    @patch('config.main.clicommon.run_command')
+    def test_add_del_interface_valid_ipv4(self, mock_run):
         db = Db()
         runner = CliRunner()
         obj = {'config_db':db.cfgdb}
@@ -69,19 +70,18 @@ class TestConfigIP(object):
         # config int ip remove Ethernet64 10.10.10.1/24
         result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["remove"], ["Ethernet64", "10.10.10.1/24"], obj=obj)
         print(result.exit_code, result.output)
-        assert result.exit_code != 0
+        assert result.exit_code == 0
         assert ('Ethernet64', '10.10.10.1/24') not in db.cfgdb.get_table('INTERFACE')
 
         # config int ip remove Ethernet0.10 10.11.10.1/24
         result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["remove"], ["Ethernet0.10", "10.11.10.1/24"], obj=obj)
-        print(result.exit_code, result.output)
-        assert result.exit_code != 0
+        assert result.exit_code == 0
         assert ('Ethernet0.10', '10.11.10.1/24') not in db.cfgdb.get_table('VLAN_SUB_INTERFACE')
 
         # config int ip remove Eth36.10 32.11.10.1/24
         result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["remove"], ["Eth36.10", "32.11.10.1/24"], obj=obj)
         print(result.exit_code, result.output)
-        assert result.exit_code != 0
+        assert result.exit_code == 0
         assert ('Eth36.10', '32.11.10.1/24') not in db.cfgdb.get_table('VLAN_SUB_INTERFACE')
 
     def test_add_interface_invalid_ipv4(self):
@@ -130,8 +130,8 @@ class TestConfigIP(object):
         assert 'Error: Ethernet32 is configured as a member of portchannel.' in result.output
 
     '''  Tests for IPv6 '''
-
-    def test_add_del_interface_valid_ipv6(self):
+    @patch('config.main.clicommon.run_command')
+    def test_add_del_interface_valid_ipv6(self, mock_run):
         db = Db()
         runner = CliRunner()
         obj = {'config_db':db.cfgdb}
@@ -155,20 +155,21 @@ class TestConfigIP(object):
         # config int ip remove Ethernet72 2001:1db8:11a3:19d7:1f34:8a2e:17a0:765d/34
         result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["remove"], ["Ethernet72", "2001:1db8:11a3:19d7:1f34:8a2e:17a0:765d/34"], obj=obj)
         print(result.exit_code, result.output)
-        assert result.exit_code != 0
+        assert result.exit_code == 0
         assert ('Ethernet72', '2001:1db8:11a3:19d7:1f34:8a2e:17a0:765d/34') not in db.cfgdb.get_table('INTERFACE')
 
         result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["remove"], ["Ethernet0.10", "1010:1db8:11a3:19d7:1f34:8a2e:17a0:765d/34"], obj=obj)
         print(result.exit_code, result.output)
-        assert result.exit_code != 0
+        assert result.exit_code == 0
         assert ('Ethernet0.10', '1010:1db8:11a3:19d7:1f34:8a2e:17a0:765d/34') not in db.cfgdb.get_table('VLAN_SUB_INTERFACE')
 
         result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["remove"], ["Eth36.10", "3210:1db8:11a3:19d7:1f34:8a2e:17a0:765d/34"], obj=obj)
         print(result.exit_code, result.output)
-        assert result.exit_code != 0
+        assert result.exit_code == 0
         assert ('Eth36.10', '3210:1db8:11a3:19d7:1f34:8a2e:17a0:765d/34') not in db.cfgdb.get_table('VLAN_SUB_INTERFACE')
 
-    def test_del_interface_case_sensitive_ipv6(self):
+    @patch('config.main.clicommon.run_command')
+    def test_del_interface_case_sensitive_ipv6(self, mock_run):
         db = Db()
         runner = CliRunner()
         obj = {'config_db':db.cfgdb}
@@ -179,7 +180,7 @@ class TestConfigIP(object):
         # config int ip remove Ethernet72 FC00::1/126
         result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["remove"], ["Ethernet72", "FC00::1/126"], obj=obj)
         print(result.exit_code, result.output)
-        assert result.exit_code != 0
+        assert result.exit_code == 0
         assert ('Ethernet72', 'FC00::1/126') not in db.cfgdb.get_table('INTERFACE')
 
     def test_add_interface_invalid_ipv6(self):
@@ -204,7 +205,8 @@ class TestConfigIP(object):
         assert result.exit_code != 0
         assert ERROR_MSG in result.output
 
-    def test_add_del_interface_ipv6_with_leading_zeros(self):
+    @patch('config.main.clicommon.run_command')
+    def test_add_del_interface_ipv6_with_leading_zeros(self, mock_run):
         db = Db()
         runner = CliRunner()
         obj = {'config_db':db.cfgdb}
@@ -218,10 +220,11 @@ class TestConfigIP(object):
         # config int ip remove Ethernet68 2001:0db8:11a3:09d7:1f34:8a2e:07a0:765d/34
         result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["remove"], ["Ethernet68", "2001:0db8:11a3:09d7:1f34:8a2e:07a0:765d/34"], obj=obj)
         print(result.exit_code, result.output)
-        assert result.exit_code != 0
+        assert result.exit_code == 0
         assert ('Ethernet68', '2001:db8:11a3:9d7:1f34:8a2e:7a0:765d/34') not in db.cfgdb.get_table('INTERFACE')
 
-    def test_add_del_interface_shortened_ipv6_with_leading_zeros(self):
+    @patch('config.main.clicommon.run_command')
+    def test_add_del_interface_shortened_ipv6_with_leading_zeros(self, mock_run):
         db = Db()
         runner = CliRunner()
         obj = {'config_db':db.cfgdb}
@@ -235,7 +238,7 @@ class TestConfigIP(object):
         # config int ip remove Ethernet68 3000::001/64
         result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["remove"], ["Ethernet68", "3000::001/64"], obj=obj)
         print(result.exit_code, result.output)
-        assert result.exit_code != 0
+        assert result.exit_code == 0
         assert ('Ethernet68', '3000::1/64') not in db.cfgdb.get_table('INTERFACE')
 
     def test_intf_vrf_bind_unbind(self):

--- a/tests/vlan_test.py
+++ b/tests/vlan_test.py
@@ -10,6 +10,7 @@ import show.main as show
 from utilities_common.db import Db
 from importlib import reload
 import utilities_common.bgp_util as bgp_util
+from mock import patch
 
 IP_VERSION_PARAMS_MAP = {
     "ipv4": {
@@ -355,6 +356,7 @@ class TestVlan(object):
         assert result.exit_code != 0
         assert "Error: vlan: 1027 can not be removed. First remove vxlan mapping" in result.output
 
+    @patch('config.main.clicommon.run_command', mock.Mock(return_value=True))
     def test_config_vlan_del_vlan(self, mock_restart_dhcp_relay_service):
         runner = CliRunner()
         db = Db()
@@ -370,11 +372,11 @@ class TestVlan(object):
         # remove vlan IP`s
         result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["remove"], ["Vlan1000", "192.168.0.1/21"], obj=obj)
         print(result.exit_code, result.output)
-        assert result.exit_code != 0
+        assert result.exit_code == 0
 
         result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["remove"], ["Vlan1000", "fc02:1000::1/64"], obj=obj)
         print(result.exit_code, result.output)
-        assert result.exit_code != 0
+        assert result.exit_code == 0
 
         # del vlan with IP
         result = runner.invoke(config.config.commands["vlan"].commands["del"], ["1000"], obj=db)
@@ -781,12 +783,12 @@ class TestVlan(object):
         result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["remove"],
                                ["Vlan1000", "192.168.0.1/21"], obj=obj)
         print(result.exit_code, result.output)
-        assert result.exit_code != 0
+        assert result.exit_code == 0
 
         result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["remove"],
                                ["Vlan1000", "fc02:1000::1/64"], obj=obj)
         print(result.exit_code, result.output)
-        assert result.exit_code != 0
+        assert result.exit_code == 0
 
         # remove vlan members
         vlan_member = db.cfgdb.get_table("VLAN_MEMBER")


### PR DESCRIPTION
the error message of "ip neigh flush",

$ ip neigh flush dev Ethernet4.10
Cannot find device "Ethernet4.10"

Rarely, the interface has been removed from the kernel and "ip neigh flush" will return error code 1. This will let test_subport.py fail.
---

fix unit test ip_config_test.py/vlan_test.py fail: mock run_command and update assertion expected result
