### PR TITLE
[Sync PR]: Sync #3177 to fix AS9817-64O pytest failed.

### DIFF
--- a/scripts/sfpshow
+++ b/scripts/sfpshow
@@ -305,7 +305,7 @@ class SFPShow(object):
         return output
 
     # Convert sfp info in DB to cli output string
-    def convert_sfp_info_to_output_string(self, sfp_info_dict):
+    def convert_sfp_info_to_output_string(self, sfp_info_dict, sfp_firmware_info_dict):
         indent = ' ' * 8
         output = ''
         is_sfp_cmis = 'cmis_rev' in sfp_info_dict
@@ -333,6 +333,8 @@ class SFPShow(object):
                         output += '{}N/A\n'.format((indent * 2))
             elif key == 'application_advertisement':
                 output += covert_application_advertisement_to_output_string(indent, sfp_info_dict)
+            elif key == 'active_firmware' or key == 'inactive_firmware':
+                output += '{}{}: {}\n'.format(indent, data_map[key], sfp_firmware_info_dict[key] if key in sfp_firmware_info_dict else 'N/A')
             else:
                 output += '{}{}: {}\n'.format(indent, data_map[key], sfp_info_dict[key])
 
@@ -441,12 +443,13 @@ class SFPShow(object):
         output = ''
 
         sfp_info_dict = state_db.get_all(state_db.STATE_DB, 'TRANSCEIVER_INFO|{}'.format(interface_name))
+        sfp_firmware_info_dict = state_db.get_all(state_db.STATE_DB, 'TRANSCEIVER_FIRMWARE_INFO|{}'.format(interface_name))
         if sfp_info_dict:
             if sfp_info_dict['type'] == RJ45_PORT_TYPE:
                 output = 'SFP EEPROM is not applicable for RJ45 port\n'
             else:
                 output = 'SFP EEPROM detected\n'
-                sfp_info_output = self.convert_sfp_info_to_output_string(sfp_info_dict)
+                sfp_info_output = self.convert_sfp_info_to_output_string(sfp_info_dict, sfp_firmware_info_dict)
                 output += sfp_info_output
 
                 if dump_dom:

--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -84,8 +84,6 @@ QSFP_DD_DATA_MAP = {
     'encoding': 'Encoding',
     'connector': 'Connector',
     'application_advertisement': 'Application Advertisement',
-    'active_firmware': 'Active Firmware Version',
-    'inactive_firmware': 'Inactive Firmware Version',
     'hardware_rev': 'Hardware Revision',
     'media_interface_code': 'Media Interface Code',
     'host_electrical_interface': 'Host Electrical Interface',
@@ -1314,9 +1312,12 @@ def update_firmware_info_to_state_db(port_name):
         state_db = SonicV2Connector(use_unix_socket_path=False, namespace=namespace)
         if state_db is not None:
             state_db.connect(state_db.STATE_DB)
-            active_firmware, inactive_firmware = platform_chassis.get_sfp(physical_port).get_transceiver_info_firmware_versions()
-            state_db.set(state_db.STATE_DB, 'TRANSCEIVER_INFO|{}'.format(port_name), "active_firmware", active_firmware)
-            state_db.set(state_db.STATE_DB, 'TRANSCEIVER_INFO|{}'.format(port_name), "inactive_firmware", inactive_firmware)
+            transceiver_firmware_info_dict = platform_chassis.get_sfp(physical_port).get_transceiver_info_firmware_versions()
+            if transceiver_firmware_info_dict is not None:
+                active_firmware = transceiver_firmware_info_dict.get('active_firmware', 'N/A')
+                inactive_firmware = transceiver_firmware_info_dict.get('inactive_firmware', 'N/A')
+                state_db.set(state_db.STATE_DB, 'TRANSCEIVER_FIRMWARE_INFO|{}'.format(port_name), "active_firmware", active_firmware)
+                state_db.set(state_db.STATE_DB, 'TRANSCEIVER_FIRMWARE_INFO|{}'.format(port_name), "inactive_firmware", inactive_firmware)
 
 # 'firmware' subgroup
 @cli.group()

--- a/tests/mock_tables/asic1/state_db.json
+++ b/tests/mock_tables/asic1/state_db.json
@@ -29,8 +29,6 @@
         "media_interface_technology" : "1550 nm DFB",
         "vendor_rev" : "XX",
         "cmis_rev" : "4.1",
-        "active_firmware" : "X.X",
-        "inactive_firmware" : "X.X",
         "supported_max_tx_power" : "4.0",
         "supported_min_tx_power" : "-22.9",
         "supported_max_laser_freq" : "196100",
@@ -69,6 +67,10 @@
         "vcchighwarning": "3.4650",
         "vcclowalarm": "2.9700",
         "vcclowwarning": "3.1349"
+    },
+    "TRANSCEIVER_FIRMWARE_INFO|Ethernet64": {
+        "active_firmware": "X.X",
+        "inactive_firmware": "X.X"
     },
     "CHASSIS_INFO|chassis 1": {
         "psu_num": "2"

--- a/tests/mock_tables/state_db.json
+++ b/tests/mock_tables/state_db.json
@@ -684,16 +684,17 @@
         "media_interface_technology" : "1550 nm DFB",
         "vendor_rev" : "XX",
         "cmis_rev" : "4.1",
-        "active_firmware" : "X.X",
-        "inactive_firmware" : "X.X",
         "supported_max_tx_power" : "4.0",
         "supported_min_tx_power" : "-22.9",
         "supported_max_laser_freq" : "196100",
         "supported_min_laser_freq" : "191300"
     },
+    "TRANSCEIVER_FIRMWARE_INFO|Ethernet64": {
+        "active_firmware": "X.X",
+        "inactive_firmware": "X.X"
+    },
     "TRANSCEIVER_INFO|Ethernet72": {
         "active_apsel_hostlane4": "N/A",
-        "active_firmware": "0.0",
         "is_replaceable": "True",
         "application_advertisement": "{1: {'host_electrical_interface_id': 'IB NDR', 'module_media_interface_id': 'Copper cable', 'media_lane_count': 4, 'host_lane_count': 4, 'host_lane_assignment_options': 17}, 2: {'host_electrical_interface_id': 'IB SDR (Arch.Spec.Vol.2)', 'module_media_interface_id': 'Copper cable', 'media_lane_count': 4, 'host_lane_count': 4, 'host_lane_assignment_options': 17}}",
         "host_electrical_interface": "N/A",
@@ -710,7 +711,6 @@
         "supported_min_laser_freq": "N/A",
         "serial": "serial1   ",
         "active_apsel_hostlane7": "N/A",
-        "inactive_firmware": "N/A",
         "active_apsel_hostlane1": "N/A",
         "type": "OSFP 8X Pluggable Transceiver",
         "cable_length": "1.0",
@@ -795,6 +795,10 @@
         "txbiashighwarning": "N/A",
         "txbiaslowalarm": "N/A",
         "txbiaslowwarning": "N/A"
+    },
+    "TRANSCEIVER_FIRMWARE_INFO|Ethernet72": {
+        "active_firmware": "0.0",
+        "inactive_firmware": "N/A"
     },
     "TRANSCEIVER_STATUS|Ethernet0": {
         "status": "67",

--- a/tests/sfputil_test.py
+++ b/tests/sfputil_test.py
@@ -151,8 +151,6 @@ class TestSfputil(object):
                 'specification_compliance': "sm_media_interface",
                 'dom_capability': "{'Tx_power_support': 'no', 'Rx_power_support': 'no', 'Voltage_support': 'no', 'Temp_support': 'no'}",
                 'nominal_bit_rate': '0',
-                'active_firmware': '0.1',
-                'inactive_firmware': '0.0',
                 'hardware_rev': '0.0',
                 'media_interface_code': '400ZR, DWDM, amplified',
                 'host_electrical_interface': '400GAUI-8 C2M (Annex 120E)',
@@ -184,7 +182,6 @@ class TestSfputil(object):
             "        Active App Selection Host Lane 6: 1\n"
             "        Active App Selection Host Lane 7: 1\n"
             "        Active App Selection Host Lane 8: 1\n"
-            "        Active Firmware Version: 0.1\n"
             "        Application Advertisement: 400G CR8 - Host Assign (0x1) - Copper cable - Media Assign (0x2)\n"
             "                                   200GBASE-CR4 (Clause 136) - Host Assign (Unknown) - Unknown - Media Assign (Unknown)\n"
             "        CMIS Revision: 5.0\n"
@@ -197,7 +194,6 @@ class TestSfputil(object):
             "        Host Lane Assignment Options: 1\n"
             "        Host Lane Count: 8\n"
             "        Identifier: QSFP-DD Double Density 8X Pluggable Transceiver\n"
-            "        Inactive Firmware Version: 0.0\n"
             "        Length Cable Assembly(m): 0\n"
             "        Media Interface Code: 400ZR, DWDM, amplified\n"
             "        Media Interface Technology: C-band tunable laser\n"
@@ -1113,7 +1109,7 @@ EEPROM hexdump for port Ethernet4
     def test_update_firmware_info_to_state_db(self, mock_chassis):
         mock_sfp = MagicMock()
         mock_chassis.get_sfp = MagicMock(return_value=mock_sfp)
-        mock_sfp.get_transceiver_info_firmware_versions.return_value = ['a.b.c', 'd.e.f']
+        mock_sfp.get_transceiver_info_firmware_versions.return_value = {'active_firmware' : 'a.b.c', 'inactive_firmware' : 'd.e.f'}
 
         sfputil.update_firmware_info_to_state_db("Ethernet0")
 


### PR DESCRIPTION
#### Why I did it
- To fix AS9817-64O pytest failed.
  - sfp::TestSfpApi::test_get_transceiver_info
  `Failed: Transceiver 1 info does not contain field: 'inactive_firmware', Transceiver 1 info does not contain field: 'active_firmware'`
  - sfpshow::test_check_sfpshow_eeprom
  `E {"changed": true, "cmd": ["sudo", "sfpshow", "eeprom"], …, "KeyError: 'active_firmware'"`
  - show_intf_xcvr::test_check_sfpshow_eeprom
  `E {"changed": true, "cmd": ["sudo", "sfpshow", "eeprom"], …, "KeyError: 'active_firmware'"`

#### How I did it
- Sync PR: CLI enhancements to revtrieve data from TRANSCEIVER_FIRMWARE_INFO table (#3177).

#### How to verify it
- Re-run pytest can pass.


