### PR TITLE
Fix enable ipv6-link-local-only fail on VLAN interface without IP

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -5350,8 +5350,11 @@ def enable_use_link_local_only(ctx, interface_name):
             ctx.fail("Interface name %s is invalid. Please enter a valid interface name!!" %(interface_name))
 
     if (interface_type == "VLAN_INTERFACE"):
-        if not clicommon.is_valid_vlan_interface(db, interface_name):
-            ctx.fail("Interface name %s is invalid. Please enter a valid interface name!!" %(interface_name))
+        if not clicommon.check_if_vlanid_exist(db, interface_name):
+            ctx.fail("Vlan: %s is invalid. Please create vlan first!!" %(interface_name))
+
+        if not clicommon.has_vlan_member(db, interface_name):
+            ctx.fail("Vlan: %s doesn't contains member. Please make sure vlan contains vlan member!" %(interface_name))
 
     portchannel_member_table = db.get_table('PORTCHANNEL_MEMBER')
 

--- a/utilities_common/cli.py
+++ b/utilities_common/cli.py
@@ -259,6 +259,13 @@ def check_if_vlanid_exist(config_db, vlan, table_name='VLAN'):
 
     return False
 
+def has_vlan_member(config_db, vlan):
+    vlan_ports_data = config_db.get_table('VLAN_MEMBER')
+    for key in vlan_ports_data:
+        if key[0] == vlan:
+            return True
+    return False
+
 def is_port_vlan_member(config_db, port, vlan):
     """Check if port is a member of vlan"""
 


### PR DESCRIPTION
**What I did**
Change the condition to be check vlan exist and has vlan member instead of vlan ip interface exist to enable ipv6-link-local-only on vlan

**Why I did it**
The ipv6-link-local-only function works even if the vlan doesn't set the ip interface.
The condition to enable ipv6-link-local-only should not be vlan ip interface exist

**How to verify it**
Enable ipv6-link-local-only for vlan which doesn't set the ip interface