### PR TITLE
[broadcom] Skip to execute the l3 nat command in "generate_dump" script if the chip does not support NAT feature

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -1474,8 +1474,12 @@ collect_broadcom() {
        save_bcmcmd_all_ns "\"fabric connectivity\"" "fabric.connect.summary"
        save_bcmcmd_all_ns "\"port status\"" "port.status.summary"
     else
-       save_bcmcmd_all_ns "\"l3 nat_ingress show\"" "broadcom.nat.ingress"
-       save_bcmcmd_all_ns "\"l3 nat_egress show\"" "broadcom.nat.egress"
+        local driver_id=$(bcmcmd "soc" | grep Driver= | awk -F '=' '{print substr($4, 1, 8)}')
+        # BCM56980, BCM56370 and BCM56275 do not support NAT feature
+        if [[ ! "$driver_id" =~ ^(BCM56980|BCM56370|BCM56275)$ ]]; then
+           save_cmd "bcmcmd \"l3 nat_ingress show\"" "broadcom.nat.ingress"
+           save_cmd "bcmcmd \"l3 nat_egress show\"" "broadcom.nat.egress"
+        fi
        save_bcmcmd_all_ns "\"ipmc table show\"" "broadcom.ipmc"
        save_bcmcmd_all_ns "\"multicast show\"" "broadcom.multicast"
        save_bcmcmd_all_ns "\"conf show\"" "conf.summary"


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Skip to execute "l3 nat_ingress show" and "l3 nat_egress show" for the chipset BCM56980, BCM56370 and BCM56275.

#### How to verify it
Run sonic-mgmt test_techsupport.py test case

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

