### PR TITLE
Looking for the SSD disk currently used by the SONiC.

### DIFF
--- a/show/platform.py
+++ b/show/platform.py
@@ -104,7 +104,14 @@ def psustatus(index, json, verbose):
 def ssdhealth(device, verbose, vendor):
     """Show SSD Health information"""
     if not device:
-        device = os.popen("lsblk -o NAME,TYPE -p | grep disk").readline().strip().split()[0]
+        # Looking for the SSD disk currently used by the SONiC.
+
+        base_device = os.popen("lsblk -l -o NAME,TYPE,MOUNTPOINT -p | grep -w '/host'").readline().strip().split()[0]
+
+        # Extract the base device name, handling both 'p' and non-'p' partitioning schemes
+        # Example : /dev/sda1 => /dev/sda
+        #           /dev/nvme0n1p2 => /dev/nvme0n1
+        device = base_device.rstrip("0123456789").split("p")[0]
     cmd = ['sudo', 'ssdutil', '-d', str(device)]
     options = ["-v"] if verbose else []
     options += ["-e"] if vendor else []


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

When a USB is plugged in, the default SSD value for the 'ssdutil' command is /dev/sda, which may cause the 'show platform ssdhealth' command to return incorrect information.

1. SONiC command "show platform ssdhealth"
2. Plugging in a USB key.
3. SONiC command "show platform ssdhealth"

```
admin@ais800-64d-1:~$ show platform ssdhealth
Device Model : N/A
Health       : N/A
Temperature  : N/A
```

#### How I did it
Use the SSD disk currently in use by the NOS as the default argument for the 'ssdutil' command.

#### How to verify it
```
admin@ais800-64d-1:~$ show platform ssdhealth
Device Model : MPT160-M8240GCB5ACT-E132
Health       : 100.0%
Temperature  : 27.0C
```


#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

