### PR TITLE
Update the test command for test_ssdhealth in show_test.py

### DIFF
--- a/tests/show_test.py
+++ b/tests/show_test.py
@@ -638,7 +638,7 @@ class TestShowPlatform(object):
         print(result.exit_code)
         print(result.output)
         assert result.exit_code == 0
-        mock_popen.assert_called_once_with('lsblk -o NAME,TYPE -p | grep disk')
+        mock_popen.assert_called_once_with("lsblk -l -o NAME,TYPE,MOUNTPOINT -p | grep -w '/host'")
         mock_run_command.assert_called_once_with(['sudo', 'ssdutil', '-d', '/dev/sda', '-v', '-e'], display_cmd=True)
 
     @patch('utilities_common.cli.run_command')


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Due to the build failure message as follows :
```
>           raise AssertionError(_error_message()) from cause
E           AssertionError: expected call not found.
E           Expected: popen('lsblk -o NAME,TYPE -p | grep disk')
E           Actual: popen("lsblk -l -o NAME,TYPE,MOUNTPOINT -p | grep -w '/host'")
```

#### How I did it
Update the test command

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

