### PR TITLE
Stop platform monitor service before fast/warm reboot

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -783,6 +783,13 @@ then
   systemctl stop "$service_name"
 fi
 
+# Stop platform monitor sevice to prevent i2c access during warm/fast reboot
+services=$(systemctl list-units --plain --no-pager --no-legend --type=service | grep platform-monitor | cut -f 1 -d' ')
+for service_name in $services
+do
+  systemctl stop "$service_name"
+done
+
 # Update the reboot cause file to reflect that user issued this script
 # Upon next boot, the contents of this file will be used to determine the
 # cause of the previous reboot


### PR DESCRIPTION
Root Cause:
Access i2c bus when fast/warm reboot would cause SMBus is busy and needs recover by power cycle.

Solution:
Stop platform monitor service before fast/warm reboot

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

