### PR TITLE
Add db_migrator major version "2_0_4" for supporting upgrade from ecSONiC 202111

### DIFF
--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -972,6 +972,15 @@ class DBMigrator():
         This is the latest version for 202012 branch
         """
         log.log_info('Handling version_2_0_2')
+        self.set_version('version_2_0_4')
+        return 'version_2_0_4'
+
+    def version_2_0_4(self):
+        """
+        Version 2_0_4
+        This is the latest version for 202111 branch
+        """
+        log.log_info('Handling version_2_0_4')
         self.set_version('version_3_0_0')
         return 'version_3_0_0'
 


### PR DESCRIPTION
#### What I did
 - Currently, the DB version "2_0_4" was not included in the db_migrator.
   - This is because the version was changed from 2 to 3 by this commit [bcc1206](https://github.com/sonic-net/sonic-utilities/commit/bcc12063a54abdad9ba1ad2d6c15139bf34d4c77#diff-b0834e8d86ce45563eb31cd07d08113ddef1aa146ef97fec15e5c27dfc20ff54R600). 
 - In ecSONiC 202111, the DB version is still in 2. 
   - It caused an error when upgrading from ecSONiC from 202111 to SONiC 202311.X through sonic-installer because there was no supported upgrade version.
 - Add db_migrator major version "2_0_4" for supporting upgrade from ecSONiC 202111 to SONiC 202311.X. 