### PR TITLE
[EVPN] The length of the VTEP name should be less than 10 characters

### DIFF
--- a/config/vxlan.py
+++ b/config/vxlan.py
@@ -28,6 +28,9 @@ def add_vxlan(db, vxlan_name, src_ip):
     if(vxlan_count > 0):
         ctx.fail("VTEP already configured.")  
 
+    if len(vxlan_name) > 10:
+       ctx.fail("The length of the VTEP name should be less than 10 characters")
+
     fvs = {'src_ip': src_ip}
     db.cfgdb.set_entry('VXLAN_TUNNEL', vxlan_name, fvs)
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Added a validation check to ensure that the VTEP (Virtual Tunnel Endpoint) name does not exceed the maximum allowed length.
#### How I did it
Implemented a string length check for VTEP names in the config vxlan add command.
If the VTEP name exceeds 10 characters, the system blocks the operation and displays an error message.
#### How to verify it
**Test with an invalid VTEP name (exceeding 10 characters):**
`admin@sonic:~$ sudo config vxlan add vtep1234567 10.1.0.32`
`Usage: config vxlan add [OPTIONS] <vxlan_name> <src_ip>`
`Try "config vxlan add -h" for help.`
`Error: The length of the VTEP name should be less than 10 characters`
The command fails as expected, displaying an appropriate error message.
**Test with a valid VTEP name (10 characters or fewer):**
`admin@sonic:~$ sudo config vxlan add vtep123456 10.1.0.32`
The command executes successfully without errors.
