### PR TITLE
Extend the start timeout of dhcp_relay service to 180s

### DIFF
--- a/sonic-utilities-data/templates/sonic.service.j2
+++ b/sonic-utilities-data/templates/sonic.service.j2
@@ -29,6 +29,9 @@ ExecStartPre={{path}}/{{manifest.service.name}}.sh start{% if multi_instance %} 
 ExecStart={{path}}/{{manifest.service.name}}.sh wait{% if multi_instance %} %i{% endif %}
 ExecStop={{path}}/{{manifest.service.name}}.sh stop{% if multi_instance %} %i{% endif %}
 RestartSec=30
+{%- if manifest.service.name == "dhcp_relay" %}
+TimeoutStartSec=180
+{%- endif %}
 
 {%- if not manifest.service.delayed %}
 [Install]


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Extend the start timeout of dhcp_relay service to 180s
#### How I did it
N/A
#### How to verify it
N/A
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

