### PR TITLE
[Vlan] Store InterfaceAliasConverter to speed up 'show vlan brief'

### DIFF
--- a/show/vlan.py
+++ b/show/vlan.py
@@ -18,7 +18,7 @@ def get_vlan_id(ctx, vlan):
 
 def get_vlan_ip_address(ctx, vlan):
     cfg, _ = ctx
-    _, vlan_ip_data, _ = cfg
+    _, vlan_ip_data, _, _ = cfg
     ip_address = ""
     for key in vlan_ip_data:
         if not clicommon.is_ip_prefix_in_key(key):
@@ -32,9 +32,8 @@ def get_vlan_ip_address(ctx, vlan):
 
 def get_vlan_ports(ctx, vlan):
     cfg, db = ctx
-    _, _, vlan_ports_data = cfg
+    _, _, vlan_ports_data, iface_alias_converter = cfg
     vlan_ports = []
-    iface_alias_converter = clicommon.InterfaceAliasConverter(db)
     # Here natsorting is important in relation to another
     # column which prints port tagging mode.
     # If we sort both in the same way using same keys
@@ -57,7 +56,7 @@ def get_vlan_ports(ctx, vlan):
 
 def get_vlan_ports_tagging(ctx, vlan):
     cfg, db = ctx
-    _, _, vlan_ports_data = cfg
+    _, _, vlan_ports_data, _ = cfg
     vlan_ports_tagging = []
     # Here natsorting is important in relation to another
     # column which prints vlan ports.
@@ -79,7 +78,7 @@ def get_vlan_ports_tagging(ctx, vlan):
 
 def get_proxy_arp(ctx, vlan):
     cfg, _ = ctx
-    _, vlan_ip_data, _ = cfg
+    _, vlan_ip_data, _, _ = cfg
     proxy_arp = "disabled"
     for key in vlan_ip_data:
         if clicommon.is_ip_prefix_in_key(key):
@@ -127,7 +126,8 @@ def brief(db, verbose):
     vlan_data = db.cfgdb.get_table('VLAN')
     vlan_ip_data = db.cfgdb.get_table('VLAN_INTERFACE')
     vlan_ports_data = db.cfgdb.get_table('VLAN_MEMBER')
-    vlan_cfg = (vlan_data, vlan_ip_data, vlan_ports_data)
+    iface_alias_converter = clicommon.InterfaceAliasConverter(db)
+    vlan_cfg = (vlan_data, vlan_ip_data, vlan_ports_data, iface_alias_converter)
 
     for vlan in natsorted(vlan_data):
         row = []


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Store InterfaceAliasConverter to speed up 'show vlan brief'

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

