### PR TITLE
Update neighbor_advertiser on VXLAN EVPN NVO Issues

### DIFF
--- a/scripts/neighbor_advertiser
+++ b/scripts/neighbor_advertiser
@@ -37,7 +37,7 @@ SYSLOG_IDENTIFIER = 'neighbor_advertiser'
 # Tunnel setup
 #
 
-MIRROR_SESSION_NAME = 'neighbor_advertiser'
+MIRROR_SESSION_NAME = 'nadv'
 MIRROR_ACL_TABLE_PREFIX = 'SONIC_'
 MIRROR_ACL_TABLE_NAME = 'EVERFLOW'
 MIRROR_ACL_TABLEV6_NAME = 'EVERFLOWV6'
@@ -529,11 +529,12 @@ def add_vxlan_tunnel(dst_ipv4_addr):
 
 def add_vxlan_tunnel_map():
     for (index, vlan_intf_name) in enumerate(get_vlan_interfaces(), 1):
+        vni = get_vlan_interface_vxlan_id(vlan_intf_name)
         vxlan_tunnel_map_info = {
-            'vni': get_vlan_interface_vxlan_id(vlan_intf_name),
+            'vni': vni,
             'vlan': vlan_intf_name
         }
-        config_db.set_entry('VXLAN_TUNNEL_MAP', (VXLAN_TUNNEL_NAME, VXLAN_TUNNEL_MAP_PREFIX + str(index)), vxlan_tunnel_map_info)
+        config_db.set_entry('VXLAN_TUNNEL_MAP', (VXLAN_TUNNEL_NAME, VXLAN_TUNNEL_MAP_PREFIX + vni + "_" + vlan_intf_name), vxlan_tunnel_map_info)
 
 
 def set_vxlan_tunnel(ferret_server_ip):
@@ -560,8 +561,9 @@ def remove_vxlan_tunnel_map():
     vxlan_tunnel = config_db.get_table('VXLAN_TUNNEL')
     if len(vxlan_tunnel):
         vxlan_tunnel_name = list(vxlan_tunnel.keys())[0]
-    for (index, _) in enumerate(get_vlan_interfaces(), 1):
-        config_db.set_entry('VXLAN_TUNNEL_MAP', (vxlan_tunnel_name, VXLAN_TUNNEL_MAP_PREFIX + str(index)), None)
+    for (index, vlan_intf_name) in enumerate(get_vlan_interfaces(), 1):
+        vni = get_vlan_interface_vxlan_id(vlan_intf_name)
+        config_db.set_entry('VXLAN_TUNNEL_MAP', (vxlan_tunnel_name, VXLAN_TUNNEL_MAP_PREFIX + vni + "_" + vlan_intf_name), None)
 
 
 def reset_vxlan_tunnel():

--- a/scripts/neighbor_advertiser
+++ b/scripts/neighbor_advertiser
@@ -45,7 +45,7 @@ MIRROR_ACL_RULE_NAME = 'rule_arp'
 MIRROR_ACL_RULEV6_NAME = 'rule_nd'
 VXLAN_TUNNEL_NAME = 'neigh_adv'
 VXLAN_TUNNEL_MAP_PREFIX = 'map_'
-
+VXLAN_EVPN_NVO_NAME = 'nvo'
 
 #
 # Path
@@ -512,6 +512,12 @@ def check_existing_tunnel():
         return True
     return False
 
+def add_vxlan_evpn_nvo():
+    nvo_info = {
+        'source_vtep': VXLAN_TUNNEL_NAME
+    }
+    config_db.set_entry('VXLAN_EVPN_NVO', VXLAN_EVPN_NVO_NAME, nvo_info)
+
 def add_vxlan_tunnel(dst_ipv4_addr):
     vxlan_tunnel_info = {
         'src_ip': get_loopback_addr(4),
@@ -534,12 +540,16 @@ def set_vxlan_tunnel(ferret_server_ip):
     if not check_existing_tunnel():
         add_vxlan_tunnel(ferret_server_ip)
     add_vxlan_tunnel_map()
+    add_vxlan_evpn_nvo()
     log.log_info('Finish setting vxlan tunnel; Ferret: {}'.format(ferret_server_ip))
 
 
 #
 # Reset vxlan tunnel
 #
+
+def remove_vxlan_evpn_nvo():
+    config_db.set_entry('VXLAN_EVPN_NVO', VXLAN_EVPN_NVO_NAME, None)
 
 def remove_vxlan_tunnel():
     config_db.set_entry('VXLAN_TUNNEL', VXLAN_TUNNEL_NAME, None)
@@ -557,6 +567,7 @@ def remove_vxlan_tunnel_map():
 def reset_vxlan_tunnel():
     remove_vxlan_tunnel_map()
     remove_vxlan_tunnel()
+    remove_vxlan_evpn_nvo()
     log.log_info('Finish resetting vxlan tunnel')
 
 

--- a/scripts/neighbor_advertiser
+++ b/scripts/neighbor_advertiser
@@ -45,7 +45,7 @@ MIRROR_ACL_RULE_NAME = 'rule_arp'
 MIRROR_ACL_RULEV6_NAME = 'rule_nd'
 VXLAN_TUNNEL_NAME = 'neigh_adv'
 VXLAN_TUNNEL_MAP_PREFIX = 'map_'
-VXLAN_EVPN_NVO_NAME = 'nvo'
+VXLAN_EVPN_NVO_NAME = 'nadv_nvo'
 
 #
 # Path

--- a/tests/neighbor_advertiser_test.py
+++ b/tests/neighbor_advertiser_test.py
@@ -62,7 +62,7 @@ class TestNeighborAdvertiser(object):
         assert(neighbor_advertiser.check_existing_tunnel())
         neighbor_advertiser.add_vxlan_tunnel_map()
         tunnel_mapping = neighbor_advertiser.config_db.get_table('VXLAN_TUNNEL_MAP')
-        expected_mapping = {("vtep1", "map_1"): {"vni": "1000", "vlan": "Vlan1000"}, ("vtep1", "map_2"): {"vni": "2000", "vlan": "Vlan2000"}}
+        expected_mapping = {("vtep1", "map_1000_Vlan1000"): {"vni": "1000", "vlan": "Vlan1000"}, ("vtep1", "map_2000_Vlan2000"): {"vni": "2000", "vlan": "Vlan2000"}}
         for key in expected_mapping.keys():
             assert(key in tunnel_mapping.keys())
             assert(expected_mapping[key] == tunnel_mapping[key])


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### Why I did it
- Fixed for test_wr_arp failures.
- Fixed issues related to VXLAN EVPN NVO handling.
#### How I did it
- Modified neighbor_advertiser to properly handle VXLAN EVPN NVO and mirror session names.
#### How to verify it
- Run sonic-mgmt/tests/arp/test_wr_arp.py to validate
- Config VXLAN_EVPN_NVO and warm reboot

<!--
#### Previous command output (if the output of a command-line utility has changed)
N/A
#### New command output (if the output of a command-line utility has changed)
N/A
-->