### PR TITLE
[LAG] Sync LAG additional function to 202311.X

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -984,10 +984,17 @@ def interface_is_in_vlan(vlan_member_table, interface_name):
 
 def interface_is_in_portchannel(portchannel_member_table, interface_name):
     """ Check if an interface is part of portchannel """
-    for _, intf in portchannel_member_table:
+    for portchannel_name, intf in portchannel_member_table:
         if intf == interface_name:
-            return True
+            return portchannel_name
 
+    return False
+
+def portchannel_is_mix_speed(config_db, portchannel_name):
+    """ Check if portchannel is mix-speed mode """
+    portchannel_data = config_db.get_entry("PORTCHANNEL", portchannel_name)
+    if "mix_speed" in portchannel_data.keys() and portchannel_data["mix_speed"] == "true":
+        return True
     return False
 
 def check_mirror_direction_config(v, direction):
@@ -2127,13 +2134,16 @@ def portchannel(db, ctx, namespace):
 
 @portchannel.command('add')
 @click.argument('portchannel_name', metavar='<portchannel_name>', required=True)
+@click.option('--lacp-key', help = "'auto' or integer (range from 1 to 65535)")
 @click.option('--min-links', default=1, type=click.IntRange(1,1024))
 @click.option('--fallback', default='false')
 @click.option('--fast-rate', default='false',
-              type=click.Choice(['true', 'false'],
-                                case_sensitive=False))
+        type=click.Choice(['true', 'false'],  case_sensitive=False))
+@click.option('--static', default='false', type=click.Choice(['true', 'false']),
+        help = "The lacp_key, fast_rate, min_link and fallback are not supported on static mode.")
+@click.option('--mix-speed', default='false', type=click.Choice(['true', 'false']))
 @click.pass_context
-def add_portchannel(ctx, portchannel_name, min_links, fallback, fast_rate):
+def add_portchannel(ctx, portchannel_name, lacp_key, min_links, fallback, static, fast_rate, mix_speed):
     """Add port channel"""
 
     fvs = {
@@ -2141,7 +2151,22 @@ def add_portchannel(ctx, portchannel_name, min_links, fallback, fast_rate):
         'mtu': '9100',
         'lacp_key': 'auto',
         'fast_rate': fast_rate.lower(),
+        'mix_speed': mix_speed
     }
+
+    if static == 'true':
+        fvs['static'] = 'true'
+        if lacp_key != None or min_links != 1 or fallback != 'false':
+            ctx.fail("The lacp_key, min_link and fallback are not supported on static mode.")
+    elif lacp_key != None:
+        if lacp_key == 'auto':
+            fvs['lacp_key'] = lacp_key
+        elif lacp_key.isdigit() and int(lacp_key) > 0 and int(lacp_key) < 65536:
+            fvs['lacp_key'] = lacp_key
+        else:
+            ctx.fail("lacp-key invalid, should be 'auto' or integer (range from 1 to 65535)")
+    else:
+        fvs['lacp_key'] = 'auto'
 
     if min_links != 0:
         fvs['min_links'] = str(min_links)
@@ -2253,7 +2278,7 @@ def add_portchannel_member(ctx, portchannel_name, port_name):
                 member_port_entry = db.get_entry('PORT', v)
                 port_entry = db.get_entry('PORT', port_name)
 
-                if member_port_entry is not None and port_entry is not None:
+                if member_port_entry is not None and port_entry is not None and not portchannel_is_mix_speed(db, portchannel_name):
                     member_port_speed = member_port_entry.get(PORT_SPEED)
 
                     port_speed = port_entry.get(PORT_SPEED) # TODO: MISSING CONSTRAINT IN YANG MODEL
@@ -4439,6 +4464,11 @@ def speed(ctx, interface_name, interface_speed, verbose):
         interface_name = interface_alias_to_name(config_db, interface_name)
         if interface_name is None:
             ctx.fail("'interface_name' is None!")
+
+    portchannel_member_table = config_db.get_table('PORTCHANNEL_MEMBER')
+    portchannel_name = interface_is_in_portchannel(portchannel_member_table, interface_name)
+    if portchannel_name is not False and not portchannel_is_mix_speed(config_db, portchannel_name):
+        ctx.fail("{} is member of {} which is not a mix-speed PortChannel. Configuration is not allowed!".format(interface_name, portchannel_name))
 
     log.log_info("'interface speed {} {}' executing...".format(interface_name, interface_speed))
 

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -4851,14 +4851,18 @@ This command displays information regarding port-channel interfaces
 - Example:
   ```
   admin@sonic:~$ show interfaces portchannel
-  Flags: A - active, I - inactive, Up - up, Dw - Down, N/A - not available, S - selected, D - deselected
-    No.  Team Dev       Protocol     Ports
-  -----  -------------  -----------  ---------------------------
-     24  PortChannel24  LACP(A)(Up)  Ethernet28(S) Ethernet24(S)
-     48  PortChannel48  LACP(A)(Up)  Ethernet52(S) Ethernet48(S)
-     40  PortChannel40  LACP(A)(Up)  Ethernet44(S) Ethernet40(S)
-      0  PortChannel0   LACP(A)(Up)  Ethernet0(S) Ethernet4(S)
-      8  PortChannel8   LACP(A)(Up)  Ethernet8(S) Ethernet12(S)
+  Flags: A - active, I - inactive, Up - up, Dw - Down, N/A - not available,
+         S - selected, D - deselected, * - not synced,
+         M - mixed speed
+    No.  Team Dev         Protocol     Ports                        Oper Key  Admin Key  Fast Rate
+  -----  ---------------  -----------  ---------------------------  --------  ---------  ---------
+      0  PortChannel0     LACP(A)(Up)  Ethernet0(S) Ethernet4(S)    1         1          false
+      2  PortChannel2     NONE(-)(Up)  Ethernet2(S) Ethernet1(S)    N/A       N/A        N/A
+      5  PortChannel5     LACP(A)(Dw)  N/A                          N/A       auto       false
+      8  PortChannel8(M)  LACP(A)(Up)  Ethernet8(S) Ethernet12(S)   8         8          ture
+     24  PortChannel24    LACP(A)(Up)  Ethernet28(S) Ethernet24(S)  124       auto       false
+     40  PortChannel40    LACP(A)(Up)  Ethernet44(S) Ethernet40(S)  40        40         false
+     48  PortChannel48    LACP(A)(Up)  Ethernet52(S) Ethernet48(S)  48        48         false
   ```
 
 **show interface status**
@@ -8185,16 +8189,47 @@ This command displays all the port channels that are configured in the device an
 - Example:
   ```
   admin@sonic:~$ show interfaces portchannel
-  Flags: A - active, I - inactive, Up - up, Dw - Down, N/A - not available, S - selected, D - deselected
-    No.  Team Dev       Protocol     Ports
-  -----  -------------  -----------  ---------------------------
-     24  PortChannel24  LACP(A)(Up)  Ethernet28(S) Ethernet24(S)
-     48  PortChannel48  LACP(A)(Up)  Ethernet52(S) Ethernet48(S)
-     40  PortChannel40  LACP(A)(Up)  Ethernet44(S) Ethernet40(S)
-      0  PortChannel0   LACP(A)(Up)  Ethernet0(S) Ethernet4(S)
-      8  PortChannel8   LACP(A)(Up)  Ethernet8(S) Ethernet12(S)
+  Flags: A - active, I - inactive, Up - up, Dw - Down, N/A - not available,
+         S - selected, D - deselected, * - not synced,
+         M - mixed speed
+    No.  Team Dev         Protocol     Ports                        Oper Key  Admin Key  Fast Rate
+  -----  -------------    -----------  ---------------------------  --------  ---------  ---------
+      0  PortChannel0     LACP(A)(Up)  Ethernet0(S) Ethernet4(S)    1         1          false
+      2  PortChannel2     NONE(-)(Up)  Ethernet2(S) Ethernet1(S)    N/A       N/A        N/A
+      5  PortChannel5     LACP(A)(Dw)  N/A                          N/A       auto       false
+      8  PortChannel8(M)  LACP(A)(Up)  Ethernet8(S) Ethernet12(S)   8         8          ture
+     24  PortChannel24    LACP(A)(Up)  Ethernet28(S) Ethernet24(S)  124       auto       false
+     40  PortChannel40    LACP(A)(Up)  Ethernet44(S) Ethernet40(S)  40        40         false
+     48  PortChannel48    LACP(A)(Up)  Ethernet52(S) Ethernet48(S)  48        48         false
   ```
 
+  Protocol
+  - LACP protocol mode, active (A) or inactive(I) on the port channel.
+    - LACP(A) means LACPDU frames are sent along the configured links periodically.
+    - LACP(I) means the port channel is not in an active negotiating state. It acts as "speak when spoken to",  does respond to incoming LACP packets.
+  - The 'NONE' keyword means static port channel.
+  - The port channel state, (Up) or (Dw).
+
+  Ports
+  - S - selected, the port is already attached to the port channel and ready to transmit and receive.
+  - D - deselected,  the port is not attached to the port channel yet.
+  - \* - not synced, the port is not synchronized. It is currently not in the right aggregation.
+
+  Oper Key and Admin Key
+  - The Admin Key is specified value in "--lacp-key" option of config portchannel add command.
+  - The Oper Key is value of actually participating in the LACP protocol.
+
+  Fast Rate
+  - It is used to set the rate at which the LACP control packets are sent from partner.
+    - true means LACP fast rate mode, request partner to transmit LACPDUs every 1 second.
+    - false means LACP slow rate mode, request partner to transmit LACPDUs every 30 seconds.
+    - N/A, it is meaningless for static port channel.
+
+  Mix Speed
+  - M - Show which portchannel is in mixed speed mode.
+    - In mixed speed mode, it is allowed to combine ports with different speeds into a single port channel.
+
+  Note: If user created a port channel and set lacp-key as "auto", the "Oper Key" value will be generated automatically after first port channel member is added to port channel.
 
 ### PortChannel Config commands
 
@@ -8202,28 +8237,43 @@ This sub-section explains how to configure the portchannel and its member ports.
 
 **config portchannel**
 
-This command is used to add or delete the portchannel.
-It is recommended to use portchannel names in the format "PortChannelxxxx", where "xxxx" is number of 1 to 4 digits. Ex: "PortChannel0002".
-
-NOTE: If users specify any other name like "pc99", command will succeed, but such names are not supported. Such names are not printed properly in the "show interface portchannel" command. It is recommended not to use such names.
-
-When any port is already member of any other portchannel and if user tries to add the same port in some other portchannel (without deleting it from the current portchannel), the command fails internally. But, it does not print any error message. In such cases, remove the member from current portchannel and then add it to new portchannel.
-
-Command takes two optional arguements given below.
-1) min-links  - minimum number of links required to bring up the portchannel
-2) fallback - true/false. LACP fallback feature can be enabled / disabled.  When it is set to true, only one member port will be selected as active per portchannel during fallback mode. Refer https://github.com/sonic-net/SONiC/blob/master/doc/lag/LACP%20Fallback%20Feature%20for%20SONiC_v0.5.md for more details about fallback feature.
-3) fast-rate - true/false, default is false (slow). Option specifying the rate in which we'll ask our link partner to transmit LACPDU packets in 802.3ad mode. slow - request partner to transmit LACPDUs every 30 seconds, fast - request partner to transmit LACPDUs every 1 second. In slow mode 60-90 seconds needed to detect linkdown, in fast mode only 2-3 seconds.
-
-A port channel can be deleted only if it does not have any members or the members are already deleted. When a user tries to delete a port channel and the port channel still has one or more members that exist, the deletion of port channel is blocked.
+This command is used to add or delete a port channel. User can specify some attributes of the port channel when adding the port channel name.
 
 - Usage:
   ```
-  config portchannel (add | del) <portchannel_name> [--min-links <num_min_links>] [--fallback (true | false)  [--fast-rate (true | false)]
+  config portchannel (add | del) <portchannel_name> [--min-links <num_min_links>] [--fallback (true | false)] [--static (true | false)] [--fast-rate (true | false)] [--mix-speed (true | false)]
   ```
 
-- Example (Create the portchannel with name "PortChannel0011"):
+  Parameter:
+  - add, add a new port-channel name in the system.
+  - del, delete the port-channel name from the system.
+  - <portchannel_name>, the port channel name to be added or deleted. The syntax of port channel name is "PortChannel"+<suffix> where <suffix> range is 0..9999. For example, the name could be "PortChannel200".
+  - --min-links <num_min_links>, minimum number of links in the port channel before the port channel can be brought up and active. The default value is 1. The range from 1 to 1024.
+  - --fallback option, LACP fallback feature can be enabled/disabled. The default value is false.
+    - true, enable LACP fallback, which keep the port channel stays in "up" before receiving any LACP PDUs from peer DUT.
+    - false, disable LACP fallback, turn the port channel state to down when it does not receive the LACP PDUs from peer DUT.
+  - --lacp-key <num_lacp_key>, specify the exchanged lacp-key in LACP protocol, either auto or <num_lacp_key>. The default value is auto.
+    - auto, it concatenates "1"+<suffix> as the key. For example, <suffix> uses "200", the lacp_key would be "1200".
+    - <num_lacp_key>, the range of given number from 1 to 65535.
+  - --static, specify the port channel type, either true for static port channel or false for dynamic LACP port channel.
+  - --fast-rate, specify LACP rate mode.
+    - true, LACP fast rate mode, request partner to transmit LACPDUs every 1 second. LACP timeout is 3 seconds.
+    - false, LACP slow rate mode, request partner to transmit LACPDUs every 30 seconds. LACP timeout is 90 seconds.
+    - the default value is false.
+  - --mix-speed, specify whether the port channel is allowed to combine ports with different speeds into a single port channel. Default is false.
+  Note:
+  1. If any port is already member of a port channel and a user tries to add the same port to another port channel (without first deleting it from the current port channel), the command fails and error message is printed. In such cases, remove the member port from the current port channel and then add it to new port channel.
+  2. A port channel can be deleted only if it does not have any members or the members are already deleted. When a user tries to delete a port channel and the port channel still has one or more members that exist, the deletion of port channel is blocked.
+  3. Refer to https://github.com/Azure/SONiC/blob/master/doc/lag/LACP%20Fallback%20Feature%20for%20SONiC_v0.5.md for more details about the fallback feature.
+  4. Only --static option is required when adding static port channel. Extra option, such as lacp_key, fast-rate, min_link, or fallback, would cause an error.
+  5. The attributes of created port channel cannot be modified or changed.
+     - If port channel is already created and user tries to specify options to change port channel attributes, the command fails and error message is printed.
+
+Create a port-channel with name: "PortChannel200"
+
+- Example (Create the portchannel with name "PortChannel200"):
   ```
-  admin@sonic:~$ sudo config portchannel add PortChannel0011
+  admin@sonic:~$ sudo config portchannel add PortChannel200
   ```
 
 **config portchannel member**
@@ -8235,9 +8285,9 @@ This command adds or deletes a member port to/from the already created portchann
   config portchannel member (add | del) <portchannel_name> <member_portname>
   ```
 
-- Example (Add interface Ethernet4 as member of the portchannel "PortChannel0011"):
+- Example (Add interface Ethernet4 as member of the portchannel "PortChannel200"):
   ```
-  admin@sonic:~$ sudo config portchannel member add PortChannel0011 Ethernet4
+  admin@sonic:~$ sudo config portchannel member add PortChannel200 Ethernet4
   ```
 
 Go Back To [Beginning of the document](#) or [Beginning of this section](#portchannels)
@@ -8266,7 +8316,6 @@ This command displays the NVGRE tunnel configuration.
   -------------  --------
   tunnel_1       10.0.0.1
   ```
-
 **show nvgre-tunnel-map**
 
 This command displays the NVGRE tunnel map configuration.

--- a/show/interfaces/portchannel.py
+++ b/show/interfaces/portchannel.py
@@ -28,6 +28,11 @@ PORT_CHANNEL_APPL_TABLE_PREFIX = "LAG_TABLE:"
 PORT_CHANNEL_CFG_TABLE_PREFIX = "PORTCHANNEL|"
 PORT_CHANNEL_STATE_TABLE_PREFIX = "LAG_TABLE|"
 PORT_CHANNEL_STATUS_FIELD = "oper_status"
+PORT_CHANNEL_LACP_KEY_FIELD = "lacp_key"
+PORT_CHANNEL_FAST_RATE_FIELD = "fast_rate"
+PORT_CHANNEL_MIX_SPEED_FIELS = "mix_speed"
+
+PORT_APPL_TABLE_PREFIX = "PORT_TABLE:"
 
 PORT_CHANNEL_MEMBER_APPL_TABLE_PREFIX = "LAG_MEMBER_TABLE:"
 PORT_CHANNEL_MEMBER_STATE_TABLE_PREFIX = "LAG_MEMBER_TABLE|"
@@ -73,6 +78,34 @@ class Teamshow(object):
         full_table_id = PORT_CHANNEL_MEMBER_APPL_TABLE_PREFIX + port_channel_name + ":" + port_name
         return self.db.get(self.db.APPL_DB, full_table_id, PORT_CHANNEL_MEMBER_STATUS_FIELD)
 
+    def get_portchannel_admin_key(self, port_channel_name):
+        """
+            Get port channel admin lacp key from database.
+        """
+        full_table_id = PORT_CHANNEL_CFG_TABLE_PREFIX + port_channel_name
+        return self.db.get(self.db.CONFIG_DB, full_table_id, PORT_CHANNEL_LACP_KEY_FIELD)
+
+    def get_portchannel_fast_rate(self, port_channel_name):
+        """
+            Get port channel fast rate from database.
+        """
+        full_table_id = PORT_CHANNEL_CFG_TABLE_PREFIX + port_channel_name
+        return self.db.get(self.db.CONFIG_DB, full_table_id, PORT_CHANNEL_FAST_RATE_FIELD)
+
+    def get_portchannel_oper_key(self, port_name):
+        """
+            Get port channel oper lacp key from database.
+        """
+        full_table_id = PORT_APPL_TABLE_PREFIX + port_name
+        return self.db.get(self.db.APPL_DB, full_table_id, PORT_CHANNEL_LACP_KEY_FIELD)
+
+    def get_portchannel_mix_speed(self, port_channel_name):
+        """
+            Get port channel admin lacp key from database.
+        """
+        full_table_id = PORT_CHANNEL_CFG_TABLE_PREFIX + port_channel_name
+        return self.db.get(self.db.CONFIG_DB, full_table_id, PORT_CHANNEL_MIX_SPEED_FIELS)
+
     def get_team_id(self, team):
         """
             Skip the 'PortChannel' prefix and extract the team id.
@@ -105,10 +138,21 @@ class Teamshow(object):
                 info['protocol'] = 'N/A'
                 self.summary[team_id] = info
                 self.summary[team_id]['ports'] = ''
+                self.summary[team_id]['admin_key'] = ''
+                self.summary[team_id]['oper_key'] = ''
+                self.summary[team_id]['fast_rate'] = ''
+                self.summary[team_id]['mix_speed'] = False
                 continue
             state = self.teamsraw[team_id]
-            info['protocol'] = "LACP"
-            info['protocol'] += "(A)" if state['runner.active'] == "true" else '(I)'
+            if state['setup.runner_name'] == 'lacp':
+                info['protocol'] = "LACP"
+                info['protocol'] += "(A)" if state['runner.active'] == "true" else '(I)'
+                fast_rate = self.get_portchannel_fast_rate(team)
+                info['fast_rate'] = fast_rate if fast_rate == "true" else "false"
+            else:
+                info['protocol'] = "NONE"
+                info['protocol'] += "(-)"
+                info['fast_rate'] = "N/A"
 
             portchannel_status = self.get_portchannel_status(team)
             if portchannel_status is None:
@@ -121,15 +165,27 @@ class Teamshow(object):
                 info['protocol'] += '(N/A)'
 
             info['ports'] = ""
+            info['oper_key'] = 'N/A'
+
+            admin_key = self.get_portchannel_admin_key(team)
+            info['admin_key'] = admin_key if admin_key else 'N/A'
+
+            mix_speed = self.get_portchannel_mix_speed(team) == "true"
+            info['mix_speed'] = mix_speed
+
             member_keys = self.db.keys(self.db.STATE_DB, PORT_CHANNEL_MEMBER_STATE_TABLE_PREFIX+team+'|*')
-            if member_keys is None:
+            if not member_keys:
                 info['ports'] = 'N/A'
             else:
                 ports = [key[len(PORT_CHANNEL_MEMBER_STATE_TABLE_PREFIX+team+'|'):] for key in member_keys]
+                break_line = False
                 for port in ports:
                     status = self.get_portchannel_member_status(team, port)
                     pstate = self.db.get_all(self.db.STATE_DB, PORT_CHANNEL_MEMBER_STATE_TABLE_PREFIX+team+'|'+port)
-                    selected = True if pstate['runner.aggregator.selected'] == "true" else False
+                    if state['setup.runner_name'] == 'lacp':
+                        selected = True if pstate['runner.aggregator.selected'] == "true" else False
+                    else:
+                        selected = True if pstate['link_watches.list.link_watch_0.up'] == "true" else False
                     if clicommon.get_interface_naming_mode() == "alias":
                         alias = clicommon.InterfaceAliasConverter().name_to_alias(port)
                         info["ports"] += alias + "("
@@ -139,6 +195,12 @@ class Teamshow(object):
                     if status is None or (status == "enabled" and not selected) or (status == "disabled" and selected):
                         info["ports"] += "*"
                     info["ports"] += ") "
+                    if break_line:
+                        info["ports"] += "\n"
+                    break_line ^= 1
+                oper_key = self.get_portchannel_oper_key(next(iter(ports)))
+                if oper_key:
+                    info['oper_key'] = oper_key
 
             self.summary[team_id] = info
 
@@ -147,12 +209,15 @@ class Teamshow(object):
             Display the portchannel (team) summary.
         """
         print("Flags: A - active, I - inactive, Up - up, Dw - Down, N/A - not available,\n"
-              "       S - selected, D - deselected, * - not synced")
+              "       S - selected, D - deselected, * - not synced,\n"
+              "       M - mixed speed")
 
-        header = ['No.', 'Team Dev', 'Protocol', 'Ports']
+        header = ['No.', 'Team Dev', 'Protocol', 'Ports', 'Oper Key', 'Admin Key', 'Fast Rate']
         output = []
         for team_id in natsorted(self.summary):
-            output.append([team_id, 'PortChannel'+team_id, self.summary[team_id]['protocol'], self.summary[team_id]['ports']])
+            output.append([team_id, 'PortChannel'+team_id+("(M)"if self.summary[team_id]['mix_speed'] else ""), \
+            self.summary[team_id]['protocol'], self.summary[team_id]['ports'], \
+            self.summary[team_id]['oper_key'], self.summary[team_id]['admin_key'], self.summary[team_id]['fast_rate']])
         print(tabulate(output, header))
 
 # 'portchannel' subcommand ("show interfaces portchannel")

--- a/tests/interfaces_test.py
+++ b/tests/interfaces_test.py
@@ -122,26 +122,28 @@ Ethernet1/1  ARISTA01T2  Ethernet1       None                172.16.137.56   Spi
 
 show_interfaces_portchannel_output="""\
 Flags: A - active, I - inactive, Up - up, Dw - Down, N/A - not available,
-       S - selected, D - deselected, * - not synced
-  No.  Team Dev         Protocol     Ports
------  ---------------  -----------  --------------
- 0001  PortChannel0001  LACP(A)(Dw)  Ethernet112(D)
- 0002  PortChannel0002  LACP(A)(Up)  Ethernet116(S)
- 0003  PortChannel0003  LACP(A)(Up)  Ethernet120(S)
- 0004  PortChannel0004  LACP(A)(Up)  N/A
- 1001  PortChannel1001  N/A
+       S - selected, D - deselected, * - not synced,
+       M - mixed speed
+  No.  Team Dev            Protocol     Ports           Oper Key    Admin Key    Fast Rate
+-----  ------------------  -----------  --------------  ----------  -----------  -----------
+ 0001  PortChannel0001     LACP(A)(Dw)  Ethernet112(D)  123         123          false
+ 0002  PortChannel0002     LACP(A)(Up)  Ethernet116(S)  10002       auto         false
+ 0003  PortChannel0003     NONE(-)(Up)  Ethernet120(S)  N/A         N/A          N/A
+ 0004  PortChannel0004(M)  LACP(A)(Up)  N/A             N/A         auto         true
+ 1001  PortChannel1001     N/A
 """
 
 show_interfaces_portchannel_in_alias_mode_output="""\
 Flags: A - active, I - inactive, Up - up, Dw - Down, N/A - not available,
-       S - selected, D - deselected, * - not synced
-  No.  Team Dev         Protocol     Ports
------  ---------------  -----------  --------
- 0001  PortChannel0001  LACP(A)(Dw)  etp29(D)
- 0002  PortChannel0002  LACP(A)(Up)  etp30(S)
- 0003  PortChannel0003  LACP(A)(Up)  etp31(S)
- 0004  PortChannel0004  LACP(A)(Up)  N/A
- 1001  PortChannel1001  N/A
+       S - selected, D - deselected, * - not synced,
+       M - mixed speed
+  No.  Team Dev            Protocol     Ports     Oper Key    Admin Key    Fast Rate
+-----  ------------------  -----------  --------  ----------  -----------  -----------
+ 0001  PortChannel0001     LACP(A)(Dw)  etp29(D)  123         123          false
+ 0002  PortChannel0002     LACP(A)(Up)  etp30(S)  10002       auto         false
+ 0003  PortChannel0003     NONE(-)(Up)  etp31(S)  N/A         N/A          N/A
+ 0004  PortChannel0004(M)  LACP(A)(Up)  N/A       N/A         auto         true
+ 1001  PortChannel1001     N/A
 """
 
 class TestInterfaces(object):
@@ -294,7 +296,7 @@ class TestInterfaces(object):
         traceback.print_tb(result.exc_info[2])
         assert result.exit_code == 0
         assert result.output == show_interfaces_portchannel_in_alias_mode_output
-       
+
     @mock.patch('sonic_py_common.multi_asic.get_port_table', mock.MagicMock(return_value={}))
     def test_supervisor_show_interfaces_alias_etp1_with_waring(self):
         runner = CliRunner()

--- a/tests/mock_tables/appl_db.json
+++ b/tests/mock_tables/appl_db.json
@@ -121,7 +121,8 @@
         "tpid": "0x8100",
         "fec": "rs",
         "admin_status": "up",
-        "link_training": "off"
+        "link_training": "off",
+        "lacp_key": "123"
     },
     "PORT_TABLE:Ethernet116": {
         "index": "29",
@@ -134,7 +135,8 @@
         "mtu": "9100",
         "tpid": "0x8100",
         "fec": "rs",
-        "admin_status": "up"
+        "admin_status": "up",
+        "lacp_key": "10002"
     },
     "PORT_TABLE:Ethernet120": {
         "index": "30",
@@ -147,7 +149,8 @@
         "mtu": "9100",
         "tpid": "0x8100",
         "fec": "rs",
-        "admin_status": "up"
+        "admin_status": "up",
+        "lacp_key": ""
     },
     "PORT_TABLE:Ethernet124": {
         "index": "31",
@@ -160,7 +163,8 @@
         "mtu": "9100",
         "tpid": "0x8100",
         "fec": "auto",
-        "admin_status": "up"
+        "admin_status": "up",
+        "lacp_key": "10004"
     },
     "PORT_TABLE:Ethernet200": {
         "index": "200",

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -175,7 +175,7 @@
         "mtu": "9100",
         "tpid": "0x8100",
         "pfc_asym": "off",
-        "speed": "40000"
+        "speed": "10"
     },
     "PORT|Ethernet56": {
         "admin_status": "up",
@@ -672,35 +672,47 @@
         "members@": "Ethernet32",
         "min_links": "1",
         "tpid": "0x8100",
-        "mtu": "9100"
+        "mtu": "9100",
+        "lacp_key": "auto",
+        "fast_rate": "false"
     },
     "PORTCHANNEL|PortChannel0001": {
         "admin_status": "up",
         "members@": "Ethernet112",
         "min_links": "1",
         "tpid": "0x8100",
-        "mtu": "9100"
+        "mtu": "9100",
+        "lacp_key": "123",
+        "fast_rate": "false"
     },
     "PORTCHANNEL|PortChannel0002": {
         "admin_status": "up",
         "members@": "Ethernet116",
         "min_links": "1",
         "tpid": "0x8100",
-        "mtu": "9100"
+        "mtu": "9100",
+        "lacp_key": "auto",
+        "fast_rate": "false",
+        "mix_speed": "false"
     },
     "PORTCHANNEL|PortChannel0003": {
         "admin_status": "up",
         "members@": "Ethernet120",
         "min_links": "1",
         "tpid": "0x8100",
-        "mtu": "9100"
+        "mtu": "9100",
+        "static": "true",
+        "fast_rate": "false"
     },
     "PORTCHANNEL|PortChannel0004": {
         "admin_status": "up",
         "members@": "Ethernet124",
         "min_links": "1",
         "tpid": "0x8100",
-        "mtu": "9100"
+        "mtu": "9100",
+        "lacp_key": "auto",
+        "fast_rate": "true",
+        "mix_speed": "true"
     },
     "PORTCHANNEL_MEMBER|PortChannel1001|Ethernet32": {
         "NULL": "NULL"

--- a/tests/mock_tables/state_db.json
+++ b/tests/mock_tables/state_db.json
@@ -1075,18 +1075,8 @@
         "ifinfo.ifindex": "97"
     },
     "LAG_MEMBER_TABLE|PortChannel0003|Ethernet120": {
-        "runner.actor_lacpdu_info.state": "61",
-        "runner.state": "current",
-        "runner.partner_lacpdu_info.port": "1",
-        "runner.actor_lacpdu_info.port": "121",
-        "runner.selected": "true",
-        "runner.partner_lacpdu_info.state": "61",
         "ifinfo.dev_addr": "52:54:00:f2:e1:23",
-        "runner.partner_lacpdu_info.system": "16:0e:58:6f:3c:dd",
-        "link_watches.list.link_watch_0.up": "false",
-        "runner.actor_lacpdu_info.system": "52:54:00:f2:e1:23",
-        "runner.aggregator.selected": "true",
-        "runner.aggregator.id": "100",
+        "link_watches.list.link_watch_0.up": "true",
         "link.up": "true",
         "ifinfo.ifindex": "100"
     },
@@ -1095,6 +1085,7 @@
         "team_device.ifinfo.dev_addr": "52:54:00:f2:e1:23",
         "team_device.ifinfo.ifindex": "71",
         "setup.pid": "32",
+        "setup.runner_name": "lacp",
         "state": "ok",
         "runner.fast_rate": "false",
         "setup.kernel_team_mode_name": "loadbalance",
@@ -1105,26 +1096,26 @@
         "team_device.ifinfo.dev_addr": "52:54:00:f2:e1:23",
         "team_device.ifinfo.ifindex": "72",
         "setup.pid": "40",
+        "setup.runner_name": "lacp",
         "state": "ok",
         "runner.fast_rate": "false",
         "setup.kernel_team_mode_name": "loadbalance",
         "runner.active": "true"
     },
     "LAG_TABLE|PortChannel0003": {
-        "runner.fallback": "false",
         "team_device.ifinfo.dev_addr": "52:54:00:f2:e1:23",
         "team_device.ifinfo.ifindex": "73",
         "setup.pid": "48",
+        "setup.runner_name": "loadbalance",
         "state": "ok",
-        "runner.fast_rate": "false",
-        "setup.kernel_team_mode_name": "loadbalance",
-        "runner.active": "true"
+        "setup.kernel_team_mode_name": "loadbalance"
     },
     "LAG_TABLE|PortChannel0004": {
         "runner.fallback": "false",
         "team_device.ifinfo.dev_addr": "52:54:00:f2:e1:23",
         "team_device.ifinfo.ifindex": "74",
         "setup.pid": "56",
+        "setup.runner_name": "lacp",
         "state": "ok",
         "runner.fast_rate": "false",
         "setup.kernel_team_mode_name": "loadbalance",

--- a/tests/portchannel_test.py
+++ b/tests/portchannel_test.py
@@ -119,7 +119,7 @@ class TestPortChannel(object):
         runner = CliRunner()
         db = Db()
         obj = {'db':db.cfgdb}
-        
+
         # add a portchannel with invalid fats rate
         result = runner.invoke(config.config.commands["portchannel"].commands["add"], ["PortChannel0005", "--fast-rate", fast_rate], obj=obj)
         print(result.exit_code)
@@ -442,6 +442,30 @@ class TestPortChannel(object):
         print(result.output)
         assert result.exit_code == 0
         assert result.output == ""
+
+    def test_non_mix_speed_portchannel_can_not_bind_different_speed_po(self):
+        runner = CliRunner()
+        db = Db()
+        obj = {'db':db.cfgdb}
+
+        # add a port with different speed to non mix speed portchannel
+        result = runner.invoke(config.config.commands["portchannel"].commands["member"].commands["add"], ["PortChannel1001", "Ethernet52"], obj=obj)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert "Error: Port speed of Ethernet52 is different than the other members of the portchannel PortChannel1001" in result.output
+
+    def test_non_mix_speed_portchannel_member_can_not_change_po_speed(self):
+        runner = CliRunner()
+        db = Db()
+        obj = {'config_db':db.cfgdb}
+
+        # change non mix speed portchannel member port speed
+        result = runner.invoke(config.config.commands["interface"].commands["speed"], ["Ethernet116", "100000"], obj=obj)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert "Ethernet116 is member of PortChannel0002 which is not a mix-speed PortChannel. Configuration is not allowed!" in result.output
 
     @classmethod
     def teardown_class(cls):


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Sync LAG additional function to 202311.X

#### How I did it
Sycn LAG manual config lacp key, mix-speed member LAG, static LAG function to 202311.X

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

