### PR TITLE
Ignore error for "ip neigh flush" because interface has been removed

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -4947,7 +4947,9 @@ def remove(ctx, interface_name, ip_addr):
         command = ['sudo', 'ip', 'netns', 'exec', str(ctx.obj['namespace']), 'ip', 'neigh', 'flush', 'dev', str(interface_name), str(ip_address)]
     else:
         command = ['ip', 'neigh', 'flush', 'dev', str(interface_name), str(ip_address)]
-    clicommon.run_command(command)
+
+    # Manually flush deprecated neighbors, and ignore error because the interface might have been removed in some rare circumstances
+    clicommon.run_command(command, ignore_error = True)
 
 #
 # 'loopback-action' subcommand


### PR DESCRIPTION
the error message of "ip neigh flush":

$ ip neigh flush dev Ethernet4.10
Cannot find device "Ethernet4.10"

Rarely, the interface has been removed from the kernel and "ip neigh flush" will return error code 1. This will let test_subport.py fail.

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:


#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

-->