### PR TITLE
Ignore error for "ip neigh flush" because interface has been removed

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -4947,7 +4947,9 @@ def remove(ctx, interface_name, ip_addr):
         command = ['sudo', 'ip', 'netns', 'exec', str(ctx.obj['namespace']), 'ip', 'neigh', 'flush', 'dev', str(interface_name), str(ip_address)]
     else:
         command = ['ip', 'neigh', 'flush', 'dev', str(interface_name), str(ip_address)]
-    clicommon.run_command(command)
+
+    # Manually flush deprecated neighbors, and ignore error because the interface might have been removed in some rare circumstances
+    clicommon.run_command(command, ignore_error = True)
 
 #
 # 'loopback-action' subcommand

--- a/tests/ip_config_test.py
+++ b/tests/ip_config_test.py
@@ -43,7 +43,8 @@ class TestConfigIP(object):
     def mock_run_bgp_command():
         return ""
 
-    def test_add_del_interface_valid_ipv4(self):
+    @patch('config.main.clicommon.run_command')
+    def test_add_del_interface_valid_ipv4(self, mock_run):
         db = Db()
         runner = CliRunner()
         obj = {'config_db':db.cfgdb}
@@ -69,19 +70,19 @@ class TestConfigIP(object):
         # config int ip remove Ethernet64 10.10.10.1/24
         result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["remove"], ["Ethernet64", "10.10.10.1/24"], obj=obj)
         print(result.exit_code, result.output)
-        assert result.exit_code != 0
+        assert result.exit_code == 0
         assert ('Ethernet64', '10.10.10.1/24') not in db.cfgdb.get_table('INTERFACE')
 
         # config int ip remove Ethernet0.10 10.11.10.1/24
         result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["remove"], ["Ethernet0.10", "10.11.10.1/24"], obj=obj)
         print(result.exit_code, result.output)
-        assert result.exit_code != 0
+        assert result.exit_code == 0
         assert ('Ethernet0.10', '10.11.10.1/24') not in db.cfgdb.get_table('VLAN_SUB_INTERFACE')
 
         # config int ip remove Eth36.10 32.11.10.1/24
         result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["remove"], ["Eth36.10", "32.11.10.1/24"], obj=obj)
         print(result.exit_code, result.output)
-        assert result.exit_code != 0
+        assert result.exit_code == 0
         assert ('Eth36.10', '32.11.10.1/24') not in db.cfgdb.get_table('VLAN_SUB_INTERFACE')
 
     def test_add_interface_invalid_ipv4(self):
@@ -131,7 +132,8 @@ class TestConfigIP(object):
 
     '''  Tests for IPv6 '''
 
-    def test_add_del_interface_valid_ipv6(self):
+    @patch('config.main.clicommon.run_command')
+    def test_add_del_interface_valid_ipv6(self, mock_run):
         db = Db()
         runner = CliRunner()
         obj = {'config_db':db.cfgdb}
@@ -155,20 +157,21 @@ class TestConfigIP(object):
         # config int ip remove Ethernet72 2001:1db8:11a3:19d7:1f34:8a2e:17a0:765d/34
         result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["remove"], ["Ethernet72", "2001:1db8:11a3:19d7:1f34:8a2e:17a0:765d/34"], obj=obj)
         print(result.exit_code, result.output)
-        assert result.exit_code != 0
+        assert result.exit_code == 0
         assert ('Ethernet72', '2001:1db8:11a3:19d7:1f34:8a2e:17a0:765d/34') not in db.cfgdb.get_table('INTERFACE')
 
         result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["remove"], ["Ethernet0.10", "1010:1db8:11a3:19d7:1f34:8a2e:17a0:765d/34"], obj=obj)
         print(result.exit_code, result.output)
-        assert result.exit_code != 0
+        assert result.exit_code == 0
         assert ('Ethernet0.10', '1010:1db8:11a3:19d7:1f34:8a2e:17a0:765d/34') not in db.cfgdb.get_table('VLAN_SUB_INTERFACE')
 
         result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["remove"], ["Eth36.10", "3210:1db8:11a3:19d7:1f34:8a2e:17a0:765d/34"], obj=obj)
         print(result.exit_code, result.output)
-        assert result.exit_code != 0
+        assert result.exit_code == 0
         assert ('Eth36.10', '3210:1db8:11a3:19d7:1f34:8a2e:17a0:765d/34') not in db.cfgdb.get_table('VLAN_SUB_INTERFACE')
 
-    def test_del_interface_case_sensitive_ipv6(self):
+    @patch('config.main.clicommon.run_command')
+    def test_del_interface_case_sensitive_ipv6(self, mock_run):
         db = Db()
         runner = CliRunner()
         obj = {'config_db':db.cfgdb}
@@ -179,7 +182,7 @@ class TestConfigIP(object):
         # config int ip remove Ethernet72 FC00::1/126
         result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["remove"], ["Ethernet72", "FC00::1/126"], obj=obj)
         print(result.exit_code, result.output)
-        assert result.exit_code != 0
+        assert result.exit_code == 0
         assert ('Ethernet72', 'FC00::1/126') not in db.cfgdb.get_table('INTERFACE')
 
     def test_add_interface_invalid_ipv6(self):
@@ -204,7 +207,8 @@ class TestConfigIP(object):
         assert result.exit_code != 0
         assert ERROR_MSG in result.output
 
-    def test_add_del_interface_ipv6_with_leading_zeros(self):
+    @patch('config.main.clicommon.run_command')
+    def test_add_del_interface_ipv6_with_leading_zeros(self, mock_run):
         db = Db()
         runner = CliRunner()
         obj = {'config_db':db.cfgdb}
@@ -218,10 +222,11 @@ class TestConfigIP(object):
         # config int ip remove Ethernet68 2001:0db8:11a3:09d7:1f34:8a2e:07a0:765d/34
         result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["remove"], ["Ethernet68", "2001:0db8:11a3:09d7:1f34:8a2e:07a0:765d/34"], obj=obj)
         print(result.exit_code, result.output)
-        assert result.exit_code != 0
+        assert result.exit_code == 0
         assert ('Ethernet68', '2001:db8:11a3:9d7:1f34:8a2e:7a0:765d/34') not in db.cfgdb.get_table('INTERFACE')
 
-    def test_add_del_interface_shortened_ipv6_with_leading_zeros(self):
+    @patch('config.main.clicommon.run_command')
+    def test_add_del_interface_shortened_ipv6_with_leading_zeros(self, mock_run):
         db = Db()
         runner = CliRunner()
         obj = {'config_db':db.cfgdb}
@@ -235,7 +240,7 @@ class TestConfigIP(object):
         # config int ip remove Ethernet68 3000::001/64
         result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["remove"], ["Ethernet68", "3000::001/64"], obj=obj)
         print(result.exit_code, result.output)
-        assert result.exit_code != 0
+        assert result.exit_code == 0
         assert ('Ethernet68', '3000::1/64') not in db.cfgdb.get_table('INTERFACE')
 
     def test_intf_vrf_bind_unbind(self):

--- a/tests/vlan_test.py
+++ b/tests/vlan_test.py
@@ -10,6 +10,7 @@ import show.main as show
 from utilities_common.db import Db
 from importlib import reload
 import utilities_common.bgp_util as bgp_util
+from mock import patch
 
 IP_VERSION_PARAMS_MAP = {
     "ipv4": {
@@ -355,7 +356,8 @@ class TestVlan(object):
         assert result.exit_code != 0
         assert "Error: vlan: 1027 can not be removed. First remove vxlan mapping" in result.output
 
-    def test_config_vlan_del_vlan(self, mock_restart_dhcp_relay_service):
+    @patch('config.main.clicommon.run_command')
+    def test_config_vlan_del_vlan(self, mock_run, mock_restart_dhcp_relay_service):
         runner = CliRunner()
         db = Db()
         obj = {'config_db':db.cfgdb}
@@ -370,11 +372,11 @@ class TestVlan(object):
         # remove vlan IP`s
         result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["remove"], ["Vlan1000", "192.168.0.1/21"], obj=obj)
         print(result.exit_code, result.output)
-        assert result.exit_code != 0
+        assert result.exit_code == 0
 
         result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["remove"], ["Vlan1000", "fc02:1000::1/64"], obj=obj)
         print(result.exit_code, result.output)
-        assert result.exit_code != 0
+        assert result.exit_code == 0
 
         # del vlan with IP
         result = runner.invoke(config.config.commands["vlan"].commands["del"], ["1000"], obj=db)
@@ -772,7 +774,8 @@ class TestVlan(object):
         bgp_util.run_bgp_command = cls._old_run_bgp_command
         print("TEARDOWN")
 
-    def test_config_vlan_del_dhcp_relay_restart(self):
+    @patch('config.main.clicommon.run_command')
+    def test_config_vlan_del_dhcp_relay_restart(self, mock_run):
         runner = CliRunner()
         db = Db()
         obj = {"config_db": db.cfgdb}
@@ -781,12 +784,12 @@ class TestVlan(object):
         result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["remove"],
                                ["Vlan1000", "192.168.0.1/21"], obj=obj)
         print(result.exit_code, result.output)
-        assert result.exit_code != 0
+        assert result.exit_code == 0
 
         result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["remove"],
                                ["Vlan1000", "fc02:1000::1/64"], obj=obj)
         print(result.exit_code, result.output)
-        assert result.exit_code != 0
+        assert result.exit_code == 0
 
         # remove vlan members
         vlan_member = db.cfgdb.get_table("VLAN_MEMBER")


### PR DESCRIPTION


<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### Why I did it
- test_subport.py fails occasionally due to "ip neigh flush" returning an error when the interface is already removed.

- Error message:
$ ip neigh flush dev Ethernet4.10
Cannot find device "Ethernet4.10"

 - Fix unit test failures in ip_config_test.py and vlan_test.py - mock run_command and update assertion expected result
#### How I did it
Specify "ignore_error = True" in run_command

#### How to verify it
Repeatedly added/removed sub-port interfaces

<!--
#### Previous command output (if the output of a command-line utility has changed)
N/A
#### New command output (if the output of a command-line utility has changed)
-->
