### PR TITLE
[Docs] Correct VxLAN command parameter naming

### DIFF
--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -11062,14 +11062,14 @@ This command displays all the VRF VNI mappings.
   Total count : 1
   ```
 
-**show vxlan remote_mac <remoteip/all>**
+**show vxlan remotemac <remoteip/all>**
 
 This command displays all MACs learnt from a specified remote VTEP IP, or from all of the remote VTEP IPs for all VNIs.
 
 - Usage:
 
   ```
-  show vxlan remote_mac <remoteip/all>
+  show vxlan remotemac <remoteip/all>
   ```
 
 - Example:
@@ -11094,20 +11094,20 @@ This command displays all MACs learnt from a specified remote VTEP IP, or from a
   Total count : 2
   ```
 
-**show vxlan remote_vni <remoteip/all>**
+**show vxlan remotevni <remoteip/all>**
 
 This command displays all the VNIs learnt from the specified remote VTEP, or all the VNIs learnt from all of the remote VTEPs.
 
 - Usage:
 
   ```
-  show vxlan remote_vni <remoteip/all>
+  show vxlan remotevni <remoteip/all>
   ```
 
 - Example:
 
   ```
-  admin@sonic:~$ show vxlan remote_vni 3.3.3.3
+  admin@sonic:~$ show vxlan remotevni 3.3.3.3
   +---------+--------------+-------+
   | VLAN    | RemoteVTEP   |   VNI |
   +=========+==============+=======+


### PR DESCRIPTION
#### Why I did it
The VxLAN command documentation contained incorrect parameter names:

show vxlan remote_vni should be show vxlan remotevni
show vxlan remote_mac should be show vxlan remotemac
These inconsistencies could cause confusion for users following the documentation.

#### How I did it
Updated the command names in the documentation to match the correct CLI syntax.
Ensured consistency across all VxLAN-related command references.
#### How to verify it
Review the updated documentation to confirm that the corrected command names align with the actual CLI implementation.