### PR TITLE
Add route_check.py support for IPv4-mapped IPv6 addresses

### DIFF
--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -131,6 +131,14 @@ def print_message(lvl, *args):
 
     return msg
 
+def normalize_ip_network(ip):
+    """
+    Helper to normalize IP network string using ipaddress module.
+    For IPv4 mapped IPv6 addresses, e.g. "::ffff:a1b:bd10/128" will be normalized
+    to "::ffff:10.27.189.16/128" format.
+    """
+    net = ipaddress.ip_network(ip, strict=False)
+    return str(net)
 
 def add_prefix(ip):
     """
@@ -142,7 +150,7 @@ def add_prefix(ip):
         ip = ip + PREFIX_SEPARATOR + "32"
     else:
         ip = ip + PREFIX_SEPARATOR + "128"
-    return ip
+    return normalize_ip_network(ip)
 
 
 def add_prefix_ifnot(ip):
@@ -151,7 +159,7 @@ def add_prefix_ifnot(ip):
     :param ip: IP to add prefix as string.
     :return ip with prefix
     """
-    return str(ip_network(ip)) if ip.find(PREFIX_SEPARATOR) != -1 else add_prefix(ip)
+    return normalize_ip_network(ip) if ip.find(PREFIX_SEPARATOR) != -1 else add_prefix(ip)
 
 
 def is_local(ip):
@@ -231,7 +239,7 @@ def checkout_rt_entry(k):
     if k.startswith(ASIC_KEY_PREFIX):
         e = k.lower().split("\"", -1)[3]
         if not is_local(e):
-            return True, e
+            return True, normalize_ip_network(e)
     return False, None
 
 

--- a/tests/route_check_test_data.py
+++ b/tests/route_check_test_data.py
@@ -416,4 +416,26 @@ TEST_DATA = {
             ]
         }
     },
+    "12": {
+        DESCR: "IPv4 mapped IPv6 address route check",
+        ARGS: "route_check",
+        PRE: {
+            APPL_DB: {
+                ROUTE_TABLE: {
+                    "::ffff:10.27.189.16/127": {"ifname": "Ethernet0"},
+                    "::ffff:10.27.189.17": {"ifname": "Ethernet0"}
+                },
+                INTF_TABLE: {
+                    "Ethernet0:::ffff:a1b:bd11/127": {},
+                    "Ethernet0": {}
+                }
+            },
+            ASIC_DB: {
+                RT_ENTRY_TABLE: {
+                    RT_ENTRY_KEY_PREFIX + "::ffff:10.27.189.17/128" + RT_ENTRY_KEY_SUFFIX: {},
+                    RT_ENTRY_KEY_PREFIX + "::ffff:10.27.189.16/127" + RT_ENTRY_KEY_SUFFIX: {}
+                }
+            }
+        }
+    },
 }


### PR DESCRIPTION
Add route_check.py support for IPv4-mapped IPv6 addresses

#### Why I did it
The IPv4-mapped IPv6 address format differs between IP addresses and routes.
* For IP addresses, the format is represented in hexadecimal (e.g., ::ffff:a1b:bd11).
* For routes, the automated generation uses dotted decimal notation (e.g., ::ffff:10.27.189.17).
Previously, route_check.py would generate warning logs due to mismatches between
the interface table and the route table caused by these format differences.
This commit updates route_check.py to handle IPv4-mapped IPv6 addresses consistently,
ensuring that both formats are treated as equivalent values.

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

