### PR TITLE
[CLI] Support to configure slowpath MTU for Port

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -106,6 +106,7 @@ CFG_PORTCHANNEL_MAX_VAL = 9999
 CFG_PORTCHANNEL_NO="<0-9999>"
 
 PORT_MTU = "mtu"
+PORT_MTU_SLOWPATH = "mtu_slowpath"
 PORT_SPEED = "speed"
 PORT_TPID = "tpid"
 DEFAULT_TPID = "0x8100"
@@ -2284,19 +2285,24 @@ def add_portchannel_member(ctx, portchannel_name, port_name):
                         ctx.fail("Port speed of {} is different than the other members of the portchannel {}"
                                  .format(port_name, portchannel_name))
 
-        # Dont allow a port to be member of port channel if its MTU does not match with portchannel
+        # Dont allow a port to be member of port channel if its MTU/'Slowpath MTU' does not match with portchannel
         portchannel_entry =  db.get_entry('PORTCHANNEL', portchannel_name)
         if portchannel_entry and portchannel_entry.get(PORT_MTU) is not None :
             port_entry = db.get_entry('PORT', port_name)
+            portchannel_mtu = portchannel_entry.get(PORT_MTU) # TODO: MISSING CONSTRAINT IN YANG MODEL
 
             if port_entry and port_entry.get(PORT_MTU) is not None:
                 port_mtu = port_entry.get(PORT_MTU)
 
-                portchannel_mtu = portchannel_entry.get(PORT_MTU) # TODO: MISSING CONSTRAINT IN YANG MODEL
                 if portchannel_mtu != port_mtu:
                     ctx.fail("Port MTU of {} is different than the {} MTU size"
                              .format(port_name, portchannel_name))
 
+            if port_entry and port_entry.get(PORT_MTU_SLOWPATH) is not None:
+                port_mtu_slowpath = port_entry.get(PORT_MTU_SLOWPATH)
+                if portchannel_mtu != port_mtu_slowpath:
+                    ctx.fail("Port slowpath MTU of {} is different than the {} MTU size"
+                            .format(port_name, portchannel_name))
         # Dont allow a port to be member of port channel if its TPID is not at default 0x8100
         # If TPID is supported at LAG level, when member is added, the LAG's TPID is applied to the
         # new member by SAI.
@@ -4762,6 +4768,16 @@ def mtu(ctx, interface_name, interface_mtu, verbose):
     if interface_is_in_portchannel(portchannel_member_table, interface_name):
         ctx.fail("'interface_name' is in portchannel!")
 
+    # check mtu >= mtu_slowpath
+    port_info = config_db.get_entry('PORT', interface_name)
+
+    if len(port_info) > 0:
+        mtu_slowpath = port_info.get('mtu_slowpath', None)
+        if mtu_slowpath is not None and mtu_slowpath.isdigit():
+            if int(interface_mtu) < int(mtu_slowpath):
+                ctx.fail("Interface mtu: {} should be greater than or equal to slowpath mtu: {}".format(interface_mtu, mtu_slowpath))
+
+
     if ctx.obj['namespace'] is DEFAULT_NAMESPACE:
         command = ['portconfig', '-p', str(interface_name), '-m', str(interface_mtu)]
     else:
@@ -4770,6 +4786,44 @@ def mtu(ctx, interface_name, interface_mtu, verbose):
     if verbose:
         command += ["-vv"]
     clicommon.run_command(command, display_cmd=verbose)
+
+
+#
+# 'mtu-slowpath' subcommand
+#
+
+@interface.command()
+@click.pass_context
+@click.argument('interface_name', metavar='<interface_name>', required=True)
+@click.argument('mtu_slowpath', metavar='<mtu_slowpath>', type=click.IntRange(68, 9216), required=True)
+def mtu_slowpath(ctx, interface_name, mtu_slowpath):
+    """Set interface mtu_slowpath"""
+
+    # Get the config_db connector
+    config_db = ctx.obj['config_db']
+    if clicommon.get_interface_naming_mode() == "alias":
+        interface_name = interface_alias_to_name(config_db, interface_name)
+        if interface_name is None:
+            ctx.fail("'interface_name' is None!")
+
+    portchannel_member_table = config_db.get_table('PORTCHANNEL_MEMBER')
+    if interface_is_in_portchannel(portchannel_member_table, interface_name):
+        ctx.fail("{} is in portchannel!".format(interface_name))
+
+    # check whether this port exists
+    port_info = config_db.get_entry('PORT', interface_name);
+
+    if len(port_info) == 0:
+        ctx.fail("Invalid port {}".format(interface_name))
+
+    # check mtu >= mtu_slowpath
+    mtu = port_info.get('mtu', None)
+    if mtu is not None and mtu.isdigit():
+        if int(mtu_slowpath) > int(mtu):
+            ctx.fail("mtu_slowpath {} should not exceed the interface mtu {}".format(mtu_slowpath, mtu))
+
+    config_db.mod_entry("PORT", interface_name, {"mtu_slowpath": mtu_slowpath})
+
 
 #
 # 'tpid' subcommand

--- a/show/interfaces/__init__.py
+++ b/show/interfaces/__init__.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 
 import subprocess
 import click
@@ -15,6 +16,7 @@ import sonic_platform_base.sonic_sfp.sfputilhelper
 
 from . import portchannel
 from collections import OrderedDict
+from natsort import natsorted
 
 HWSKU_JSON = 'hwsku.json'
 
@@ -917,6 +919,39 @@ def scheduler(db, interface_name):
 
         click.echo(port_name)
         click.echo(tabulate(body, header, stralign='left') + '\n')
+
+
+# 'mtu' subcommand ("show interfaces mtu")
+@interfaces.command(name='mtu')
+@clicommon.pass_db
+def mtu(db):
+    """Show interface mtu and mtu_slowpath"""
+
+    config_db = db.cfgdb
+    appl_db = db.appldb
+    ctx = click.get_current_context()
+
+    header = ['Interface', 'MTU', 'Slowpath MTU']
+    table = []
+    appl_db_keys = appl_db.keys(appl_db.APPL_DB, "PORT_TABLE:*")
+    ports_dict = config_db.get_table('PORT')
+    for i in natsorted(appl_db_keys):
+        key = re.split(':', i, maxsplit=1)[-1].strip()
+        if key in ports_dict:
+            # 'mtu' attribute in appl_db
+            mtu = appl_db.get(appl_db.APPL_DB, "PORT_TABLE:" + key, "mtu")
+            if mtu is None:
+                mtu = "N/A"
+
+            # 'mtu_slowpath' attribute in config_db
+            mtu_slowpath = config_db.get(config_db.CONFIG_DB, "PORT|" + key, "mtu_slowpath")
+            if mtu_slowpath is None:
+                mtu_slowpath = "Not Configured"
+
+            table.append((key, mtu,mtu_slowpath))
+
+    click.echo(tabulate(table, header, tablefmt="simple",stralign='right'))
+
 
 from . import buffer as buffer_command
 from . import qos as qos_command

--- a/tests/interfaces_test.py
+++ b/tests/interfaces_test.py
@@ -6,6 +6,8 @@ from unittest import mock
 from utilities_common.intf_filter import parse_interface_in_filter
 
 import show.main as show
+import config.main as config
+from utilities_common.db import Db
 
 show_interfaces_alias_output="""\
 Name         Alias
@@ -295,6 +297,32 @@ class TestInterfaces(object):
         assert result.exit_code == 0
         assert result.output == show_interfaces_portchannel_in_alias_mode_output
        
+
+    def test_config_interfaces_mtu_slowpath(self):
+        runner = CliRunner()
+        db = Db()
+        obj = {'db':db.cfgdb, 'config_db': db.cfgdb, 'namespace': ''}
+
+        port = "Ethernet40"
+
+        # port mtu_slowpath == port mtu
+        result = runner.invoke(config.config.commands["interface"].commands["mtu-slowpath"], [port, "9100"], obj=obj)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+
+        # modify port mtu to 1500 in config_db directly
+        db.cfgdb.mod_entry("PORT", port, {'mtu' : '1500'})
+
+        # port mtu_slowpath > port mtu
+        result = runner.invoke(config.config.commands["interface"].commands["mtu-slowpath"], [port, "1600"], obj=obj)
+        err_msg = "Error: mtu_slowpath 1600 should not exceed the interface mtu 1500"
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert err_msg in result.output
+
+
     @mock.patch('sonic_py_common.multi_asic.get_port_table', mock.MagicMock(return_value={}))
     def test_supervisor_show_interfaces_alias_etp1_with_waring(self):
         runner = CliRunner()

--- a/tests/portchannel_test.py
+++ b/tests/portchannel_test.py
@@ -443,6 +443,51 @@ class TestPortChannel(object):
         assert result.exit_code == 0
         assert result.output == ""
 
+
+    def test_add_portchannel_member_which_has_different_mtu_and_mtu_slowpath(self):
+        runner = CliRunner()
+        db = Db()
+        obj = {'db':db.cfgdb, 'db_wrap':db, 'namespace':''}
+        port = "Ethernet48"
+
+        # add portchannel member
+        result = runner.invoke(config.config.commands["portchannel"].commands["member"].commands["add"], ["PortChannel1001", port], obj=obj)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+
+        # del portchannel member
+        result = runner.invoke(config.config.commands["portchannel"].commands["member"].commands["del"], ["PortChannel1001", port], obj=obj)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+
+        # modify port mtu to 1500 in config_db directly
+        db.cfgdb.mod_entry("PORT", port, {'mtu' : '1500'})
+
+        # add portchannel member should fail if port mtu != portchannel mtu
+        result = runner.invoke(config.config.commands["portchannel"].commands["member"].commands["add"], ["PortChannel1001", port], obj=obj)
+        err_msg = "Error: Port MTU of {} is different than the PortChannel1001 MTU size".format(port)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert err_msg in result.output
+
+        # reset port mtu to 9100 in config_db directly
+        db.cfgdb.mod_entry("PORT", port, {'mtu' : '9100'})
+
+        # modify port mtu_slowpath to 1500 in config_db directly
+        db.cfgdb.mod_entry("PORT", port, {'mtu_slowpath' : '1500'})
+
+        # add portchannel member should fail if port mtu_slowpath != portchannel mtu
+        result = runner.invoke(config.config.commands["portchannel"].commands["member"].commands["add"], ["PortChannel1001", port], obj=obj)
+        err_msg = "Error: Port slowpath MTU of {} is different than the PortChannel1001 MTU size".format(port)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert err_msg in result.output
+
+
     @classmethod
     def teardown_class(cls):
         os.environ['UTILITIES_UNIT_TESTING'] = "0"


### PR DESCRIPTION
#### Why I did it
- Support to chang netdev mtu in kernel only

#### How I did it
- Add CLI 'config interface mtu-slowpath <interface> <mtu_slowpath>'
- Check port slowpath MTU with portchannel MTU when add member

#### How I verified it
- Manual test
  1. Change mtu for port to 9100
  2. Change mtu_slowpath for port to 1500
  3. Check "MTU" in "show interface status Ethernet0" should be 9100
  4. Check 'mtu" in "ip link show Ethernet0" should be 1500
- Unit test

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:


#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)
-->
