### PR TITLE
Fix the error message when trying to enable kdump if kdump was already enabled

### DIFF
--- a/scripts/sonic-kdump-config
+++ b/scripts/sonic-kdump-config
@@ -395,6 +395,7 @@ def kdump_enable(verbose, kdump_enabled, memory, num_dumps, image, cmdline_file)
         if crash_kernel_mem == memory:
             if crash_kernel_mem == crash_kernel_in_cmdline:
                 print("kdump is already enabled")
+                return changed
             else:
                 changed = True
         else:


### PR DESCRIPTION
```
INFO hostcfgd[6930]: Error Unable to unload Kdump the kernel '%s' []
INFO hostcfgd[6930]: kdump is already enabled
ERR hostcfgd: sonic-kdump-config --enable - failed: return code - 1, output:#012None
```