### PR TITLE
fixed incorrect parser when show ndp

### DIFF
--- a/scripts/nbrshow
+++ b/scripts/nbrshow
@@ -224,20 +224,40 @@ class NeighShow(NbrBase):
             self.display_err()
             return
 
+        valid_states = [
+                'PERMANENT', 'NOARP', 'REACHABLE', 'STALE', 'NONE',
+                        'INCOMPLETE', 'DELAY', 'PROBE', 'FAILED'
+        ]
+
         for line in self.arpraw.splitlines()[:]:
             split = line.split()
             if 'lladdr' not in split:
                 continue
 
-            ent = split[::2]
+            ent = []
+            try:
+                ip_index = split.index("dev") - 1
+                dev_index = split.index("dev") + 1
+                mac_index = split.index("lladdr") + 1
+            except ValueError:
+                continue
 
-            if 'router' not in split:
-                ent.append(split[-1])
+            ent.append(split[ip_index])
+            ent.append(split[mac_index])
+            ent.append(split[dev_index])
+
+
+            state = '-'
+            for s in valid_states:
+                if s in split:
+                    state = s
+                    break
+
+            ent.append(state)
+
 
             if self.iface is not None:
                 ent.insert(2, self.iface)
-            else:
-                ent[1], ent[2] = ent[2], ent[1]
 
             self.nbrdata.append(ent)
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
define the state list and used to compare with output of ip neigh
#### Why I did it
the neigh information from kernel may have extra entry, the last word may not be state of neigh. It would cause parser incorrect

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

