### PR TITLE
Incorrect output of "show policer" command when minimum bandwidth is1

### DIFF
--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -1090,7 +1090,7 @@ class AclLoader(object):
             pir = val.get("pir", "")
             pbs = val.get("pbs", "")
 
-            if val["mode"] == 'packets':
+            if val["meter_type"] == 'packets':
                 cir = "{:,}".format(int(cir)) if cir != "" else ""
                 cbs = "{:,}".format(int(cbs)) if cbs != "" else ""
                 pir = "{:,}".format(int(pir)) if pir != "" else ""


### PR DESCRIPTION
#### What I did
Bug fix.

The code was incorrectly using the "mode" field to determine the policer type, which always resulted in a misinterpretation as "bytes" mode, causing display errors.

#### How I did it
Determine the display format based on whether the "meter_type" value is set to "packets" or "bytes."

#### How to verify it
Create policer with packets and bytes mode, and check the output format is correctly.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

