### PR TITLE
[Buffer] pfc / pfc-asym sync command impl and add pfc-priority-queue command

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -2478,17 +2478,25 @@ def mirror_session():
 # 'add' subgroup ('config mirror_session add ...')
 #
 
-@mirror_session.command('add')
+@mirror_session.command('add', short_help='Add ERSPAN mirror session.(Legacy support)')
 @click.argument('session_name', metavar='<session_name>', required=True)
 @click.argument('src_ip', metavar='<src_ip>', callback=validate_ipv4_address, required=True)
 @click.argument('dst_ip', metavar='<dst_ip>', callback=validate_ipv4_address, required=True)
 @click.argument('dscp', metavar='<dscp>', type=DSCP_RANGE, required=True)
 @click.argument('ttl', metavar='<ttl>', type=TTL_RANGE, required=True)
-@click.argument('gre_type', metavar='[gre_type]', callback=validate_gre_type, required=False)
+@click.argument('gre_type', metavar='[gre_type]', required=False, default='0x88be')
 @click.argument('queue', metavar='[queue]', type=QUEUE_RANGE, required=False)
 @click.option('--policer')
 def add(session_name, src_ip, dst_ip, dscp, ttl, gre_type, queue, policer):
-    """ Add ERSPAN mirror session.(Legacy support) """
+    """ Add ERSPAN mirror session.(Legacy support)
+
+        \b
+        [gre_type]: GRE type in a GRE tunnel packet. The default value is 0x88be. Valid values are:
+        - 0x88be: ERSPAN Type I.
+        - 0x22eb: ERSPAN Type III (Only support on Intel devices).
+        \b
+        [queue]: The default value is 0. Only support to change the value on Intel devices. Valid values are 0..7.
+    """
     add_erspan(session_name, src_ip, dst_ip, dscp, ttl, gre_type, queue, policer)
 
 @mirror_session.group(cls=clicommon.AbbreviationGroup, name='erspan')
@@ -2502,29 +2510,37 @@ def erspan(ctx):
 # 'add' subcommand
 #
 
-@erspan.command('add')
+@erspan.command('add', short_help='Add ERSPAN mirror session')
 @click.argument('session_name', metavar='<session_name>', required=True)
 @click.argument('src_ip', metavar='<src_ip>', callback=validate_ipv4_address, required=True)
 @click.argument('dst_ip', metavar='<dst_ip>', callback=validate_ipv4_address,required=True)
 @click.argument('dscp', metavar='<dscp>', type=DSCP_RANGE, required=True)
 @click.argument('ttl', metavar='<ttl>', type=TTL_RANGE, required=True)
-@click.argument('gre_type', metavar='[gre_type]', callback=validate_gre_type, required=False)
+@click.argument('gre_type', metavar='[gre_type]', required=False, default='0x88be')
 @click.argument('queue', metavar='[queue]', type=QUEUE_RANGE, required=False)
 @click.argument('src_port', metavar='[src_port]', required=False)
 @click.argument('direction', metavar='[direction]', required=False)
 @click.option('--policer')
 def add(session_name, src_ip, dst_ip, dscp, ttl, gre_type, queue, policer, src_port, direction):
-    """ Add ERSPAN mirror session """
+    """ Add ERSPAN mirror session
+
+        \b
+        [gre_type]: GRE type in a GRE tunnel packet. The default value is 0x88be. Valid values are:
+        - 0x88be: ERSPAN Type I.
+        - 0x22eb: ERSPAN Type III (Only support on Intel devices).
+        \b
+        [queue]: The default value is 0. Only support to change the value on Intel devices. Valid values are 0..7.
+    """
     add_erspan(session_name, src_ip, dst_ip, dscp, ttl, gre_type, queue, policer, src_port, direction)
 
 def gather_session_info(session_info, policer, queue, src_port, direction):
-    if policer:
+    if policer != None:
         session_info['policer'] = policer
 
-    if queue is not None:
+    if queue != None:
         session_info['queue'] = queue
 
-    if src_port:
+    if src_port != None:
         if clicommon.get_interface_naming_mode() == "alias":
             src_port_list = []
             for port in src_port.split(","):
@@ -2547,8 +2563,24 @@ def add_erspan(session_name, src_ip, dst_ip, dscp, ttl, gre_type, queue, policer
             "ttl": ttl
             }
 
-    if gre_type is not None:
-        session_info['gre_type'] = gre_type
+    asic_type = device_info.get_sonic_version_info().get('asic_type', '')
+
+    if (queue != None and queue != 0) and asic_type == 'broadcom':
+        raise click.BadParameter('Only Intel devices is supported to specify the queue.')
+
+    if gre_type != None:
+        try:
+            gre_type = int(gre_type, 0)
+        except:
+            raise click.BadParameter('Wrong gre type format.')
+
+        if asic_type == 'barefoot' and gre_type not in [35006, 8939]:
+            raise click.BadParameter('Only gre type 0x88be and 0x22eb are supported.')
+
+        if asic_type == 'broadcom' and gre_type != 35006:
+            raise click.BadParameter('Only gre type 0x88be and is supported.')
+
+        session_info['gre_type'] = str(gre_type)
 
     session_info = gather_session_info(session_info, policer, queue, src_port, direction)
     ctx = click.get_current_context()
@@ -2587,7 +2619,7 @@ def span(ctx):
     """ SPAN mirror session """
     pass
 
-@span.command('add')
+@span.command('add', short_help='Add SPAN mirror session')
 @click.argument('session_name', metavar='<session_name>', required=True)
 @click.argument('dst_port', metavar='<dst_port>', required=True)
 @click.argument('src_port', metavar='[src_port]', required=False)
@@ -2595,7 +2627,11 @@ def span(ctx):
 @click.argument('queue', metavar='[queue]', type=QUEUE_RANGE, required=False)
 @click.option('--policer')
 def add(session_name, dst_port, src_port, direction, queue, policer):
-    """ Add SPAN mirror session """
+    """ Add SPAN mirror session
+
+        \b
+        [queue]: The default value is 0. Only support to change the value on Intel devices. Valid values are 0..7.
+    """
     add_span(session_name, dst_port, src_port, direction, queue, policer)
 
 def add_span(session_name, dst_port, src_port, direction, queue, policer):
@@ -2609,6 +2645,11 @@ def add_span(session_name, dst_port, src_port, direction, queue, policer):
             "type" : "SPAN",
             "dst_port": dst_port,
             }
+
+    asic_type = device_info.get_sonic_version_info().get('asic_type', '')
+
+    if (queue != None and queue != 0) and asic_type == 'broadcom':
+        raise click.BadParameter('Only Intel devices is supported to specify the queue.')
 
     session_info = gather_session_info(session_info, policer, queue, src_port, direction)
     ctx = click.get_current_context()

--- a/config/qos.py
+++ b/config/qos.py
@@ -362,6 +362,103 @@ def delete(db, profile):
     config_util.delete(ctx, "TC_TO_QUEUE_MAP", profile)
 
 #
+# 'qos pfc-priority-queue' group ('config qos pfc-priority-queue ...')
+#
+@click.group('pfc-priority-queue')
+def pfc_priority_queue():
+    """Configure PFC priority to queue mapping"""
+    pass
+
+@pfc_priority_queue.command('add')
+@click.argument('profile', metavar='<profile>', required=True)
+@click.option('--pfc-priority', type=click.STRING, required=True, help="PFC priority value")
+@click.option('--queue', type=click.IntRange(0, 7), required=True, help="Queue value")
+@clicommon.pass_db
+def add(db, profile, pfc_priority, queue):
+    """Add pfc-priority-queue map profile."""
+    config_db = db.cfgdb
+    ctx = click.get_current_context()
+
+    asic_type = device_info.get_sonic_version_info().get('asic_type', '')
+    if asic_type == 'barefoot':
+        ctx.fail('Not support pfc-priority-queue profile on Intel platform.')
+
+    entry = config_db.get_entry('MAP_PFC_PRIORITY_TO_QUEUE', profile)
+    if len(entry) != 0:
+        ctx.fail("Profile '{}' already exists use update option.".format(profile))
+
+    pfcpri_queue_map = {}
+    validate_qos_map_values(ctx, "pfc-priority", pfc_priority, queue, pfcpri_queue_map)
+
+    config_util.create(ctx, "MAP_PFC_PRIORITY_TO_QUEUE", profile, pfcpri_queue_map,
+                       "QOS_PFC_PRIORITY_TO_QUEUE_MAP_TABLE")
+
+@pfc_priority_queue.command('update')
+@click.argument('profile', metavar='<profile>', required=True)
+@click.option('--pfc-priority', type=click.STRING, required=True, help="PFC priority value")
+@click.option('--queue', type=click.IntRange(0, 7), required=False, help="Queue value")
+@click.option('--remove', default=False, is_flag=True, help="Delete the mapping entry")
+@clicommon.pass_db
+def update(db, profile, pfc_priority, queue, remove):
+    """Update pfc-priority-queue map profile."""
+    config_db = db.cfgdb
+    ctx = click.get_current_context()
+
+    asic_type = device_info.get_sonic_version_info().get('asic_type', '')
+    if asic_type == 'barefoot':
+        ctx.fail('Not support pfc-priority-queue profile on Intel platform.')
+
+    entry = config_db.get_entry('MAP_PFC_PRIORITY_TO_QUEUE', profile)
+    if len(entry) == 0:
+        ctx.fail("Profile '{}' not found.".format(profile))
+
+    if remove == False and queue == None:
+        ctx.fail('--queue is a required parameter.')
+
+    pfcpri_queue_map = {}
+    validate_qos_map_values(ctx, "pfc-priority", pfc_priority, queue, pfcpri_queue_map)
+    validate_qos_map_bind_interface(db, profile, 'pfc_to_queue_map')
+
+    if remove:
+        for i in pfcpri_queue_map:
+            if i in entry:
+                del entry[i]
+
+        config_util.delete(ctx, "MAP_PFC_PRIORITY_TO_QUEUE", profile)
+
+        if len(entry) != 0:
+            config_util.create(ctx, "MAP_PFC_PRIORITY_TO_QUEUE", profile, entry,
+                               "QOS_PFC_PRIORITY_TO_QUEUE_MAP_TABLE")
+    else:
+        for i in entry:
+            if i not in pfcpri_queue_map:
+                pfcpri_queue_map[i] = entry[i]
+
+        config_util.delete(ctx, "MAP_PFC_PRIORITY_TO_QUEUE", profile)
+        config_util.create(ctx, "MAP_PFC_PRIORITY_TO_QUEUE", profile, pfcpri_queue_map,
+                           "QOS_PFC_PRIORITY_TO_QUEUE_MAP_TABLE")
+
+@pfc_priority_queue.command('del')
+@click.argument('profile', metavar='<profile>', required=True)
+@clicommon.pass_db
+def delete(db, profile):
+    """Delete pfc-priority-queue map profile."""
+    config_db = db.cfgdb
+    ctx = click.get_current_context()
+
+    asic_type = device_info.get_sonic_version_info().get('asic_type', '')
+    if asic_type == 'barefoot':
+        ctx.fail('Not support pfc-priority-queue profile on Intel platform.')
+
+    entry = config_db.get_entry('MAP_PFC_PRIORITY_TO_QUEUE', profile)
+    if len(entry) == 0:
+        ctx.fail("pfc-priority-queue profile '{}' not found.".format(profile))
+
+    validate_qos_map_bind_interface(db, profile, 'pfc_to_queue_map')
+
+    config_util.delete(ctx, "MAP_PFC_PRIORITY_TO_QUEUE", profile)
+
+#
 # 'qos' subgroup ('config interface qos ...')
 #
 
@@ -433,6 +530,20 @@ def tc_queue_interface(db, op, interface_name, profile):
     for intf in interfaces:
         update_qos_map_interface(db, op, 'tc_to_queue_map', 'TC_TO_QUEUE_MAP', profile, intf)
 
+@click.command('pfc-priority-queue')
+@click.argument('op', metavar='{bind|unbind}', type=click.Choice(['bind', 'unbind']), required=True)
+@click.argument('interface_name', metavar='<interface_name>', required=True)
+@click.argument('profile', metavar='<profile>', required=False)
+@clicommon.pass_db
+def pfc_priority_queue_interface(db, op, interface_name, profile):
+    """pfc-priority-queue policy configuration"""
+    if op == 'bind' and profile == None:
+        ctx = click.get_current_context()
+        ctx.fail("Cannot find pfc-priority-queue profile.")
+
+    update_qos_map_interface(db, op, 'pfc_to_queue_map', 'MAP_PFC_PRIORITY_TO_QUEUE', profile, interface_name)
+
+
 @qos_interface.command('dscp-tc')
 @click.argument('op', metavar='{bind|unbind}', type=click.Choice(['bind', 'unbind']), required=True)
 @click.argument('interface_name', metavar='<interface_name>', required=True)
@@ -446,6 +557,20 @@ def dscp_tc_interface(db, op, interface_name, profile):
 
     update_qos_map_interface(db, op, 'dscp_to_tc_map', 'DSCP_TO_TC_MAP', profile, interface_name)
 
+def is_pfc_not_supported_device():
+    devices = [
+        # HR4
+        'Accton-AS4625-54T',
+        'Accton-AS4625-54P',
+    ]
+
+    hwsku = device_info.get_hwsku()
+    if hwsku:
+        for device in devices:
+            if hwsku.startswith(device):
+                return True
+    return False
+
 def add_command(config_qos, interface):
     config_qos.add_command(dot1p_tc)
     config_qos.add_command(dscp_tc)
@@ -453,3 +578,7 @@ def add_command(config_qos, interface):
     config_qos.add_command(tc_queue)
 
     interface.add_command(qos_interface)
+
+    if is_pfc_not_supported_device() == False:
+        config_qos.add_command(pfc_priority_queue)
+        qos_interface.add_command(pfc_priority_queue_interface)

--- a/pfc/main.py
+++ b/pfc/main.py
@@ -4,18 +4,25 @@ import click
 from swsscommon.swsscommon import ConfigDBConnector
 from tabulate import tabulate
 from natsort import natsorted
+from utilities_common.db import Db
+import utilities_common.config_util as config_util
+import utilities_common.cli as clicommon
 
 ALL_PRIORITIES = [str(x) for x in range(8)]
 PRIORITY_STATUS = ['on', 'off']
 
-def configPfcAsym(interface, pfc_asym):
+def configPfcAsym(ctx, interface, pfc_asym):
     """
     PFC handler to configure asymmentric PFC.
     """
-    configdb = ConfigDBConnector()
-    configdb.connect()
+    config_db = ctx.obj.cfgdb
 
-    configdb.mod_entry("PORT", interface, {'pfc_asym': pfc_asym})
+    if not clicommon.is_valid_port(config_db, interface):
+        ctx.fail("interface {} doesn't exist".format(interface))
+
+    config_util.update(ctx, "PORT", interface,
+                       {'pfc_asym': pfc_asym},
+                       "PORT_PFC_ASYM_STATE_TABLE")
 
 
 def showPfcAsym(interface):
@@ -49,12 +56,14 @@ def showPfcAsym(interface):
     click.echo(tabulate(sorted_table, headers=header, tablefmt="simple", missingval=""))
     click.echo()
 
-def configPfcPrio(status, interface, priority):
-    configdb = ConfigDBConnector()
-    configdb.connect()
+def configPfcPrio(ctx, status, interface, priority):
+    config_db = ctx.obj.cfgdb
+
+    if not clicommon.is_valid_port(config_db, interface):
+        ctx.fail("interface {} doesn't exist".format(interface))
 
     """Current lossless priorities on the interface"""
-    entry = configdb.get_entry('PORT_QOS_MAP', interface)
+    entry = config_db.get_entry('PORT_QOS_MAP', interface)
     enable_prio = entry.get('pfc_enable', '').split(',')
 
     """Avoid '' in enable_prio"""
@@ -75,9 +84,12 @@ def configPfcPrio(status, interface, priority):
         enable_prio.remove(priority)
 
     enable_prio.sort()
-    configdb.mod_entry("PORT_QOS_MAP", interface,
-                      {'pfc_enable': ','.join(enable_prio),
-                       'pfcwd_sw_enable': ','.join(enable_prio)})
+
+    config_util.update(ctx, "PORT_QOS_MAP", interface,
+                       {"pfc_enable": ",".join(enable_prio),
+                        "pfcwd_sw_enable": ",".join(enable_prio)},
+                       "PORT_PFC_STATE_TABLE")
+
 
     """Show the latest PFC configuration"""
     showPfcPrio(interface)
@@ -130,17 +142,24 @@ def show():
 @click.command()
 @click.argument('status', type=click.Choice(PRIORITY_STATUS))
 @click.argument('interface', type=click.STRING)
-def configAsym(status, interface):
+@click.pass_context
+def configAsym(ctx, status, interface):
     """Configure asymmetric PFC on a given port."""
-    configPfcAsym(interface, status)
+
+    ctx.obj = Db()
+
+    configPfcAsym(ctx, interface, status)
 
 @click.command()
 @click.argument('status', type=click.Choice(PRIORITY_STATUS))
 @click.argument('interface', type=click.STRING)
 @click.argument('priority', type=click.Choice(ALL_PRIORITIES))
-def configPrio(status, interface, priority):
+@click.pass_context
+def configPrio(ctx, status, interface, priority):
     """Configure PFC on a given priority."""
-    configPfcPrio(status, interface, priority)
+
+    ctx.obj = Db()
+    configPfcPrio(ctx, status, interface, priority)
 
 @click.command()
 @click.argument('interface', type=click.STRING, required=False)

--- a/show/qos.py
+++ b/show/qos.py
@@ -106,8 +106,36 @@ def tc_queue(db, profile):
     header = ['TC', 'Queue']
     show_qos_map(db, profile, 'TC_TO_QUEUE_MAP', header, 'tc-queue')
 
+#
+# 'qos pfc-priority-queue' command ("show qos pfc-priority-queue ")
+#
+@click.command('pfc-priority-queue')
+@click.argument('profile', required=False)
+@clicommon.pass_db
+def pfcpri_queue(db, profile):
+    '''Show PFC priority to queue qos policy'''
+    header = ['PFC Priority', 'Queue']
+    show_qos_map(db, profile, 'MAP_PFC_PRIORITY_TO_QUEUE', header, 'pfc-queue')
+
+def is_pfc_not_supported_device():
+    devices = [
+        # HR4
+        'Accton-AS4625-54T',
+        'Accton-AS4625-54P',
+    ]
+
+    hwsku = device_info.get_hwsku()
+    if hwsku:
+        for device in devices:
+            if hwsku.startswith(device):
+                return True
+    return False
+
 def add_command(show_qos):
     show_qos.add_command(dot1p_tc)
     show_qos.add_command(dscp_tc)
     show_qos.add_command(tc_pg)
     show_qos.add_command(tc_queue)
+
+    if is_pfc_not_supported_device() == False:
+        show_qos.add_command(pfcpri_queue)

--- a/tests/config_mirror_session_test.py
+++ b/tests/config_mirror_session_test.py
@@ -7,66 +7,80 @@ from mock import patch
 from jsonpatch import JsonPatchConflict
 from sonic_py_common import multi_asic
 
+from sonic_py_common import device_info
+
 ERR_MSG_IP_FAILURE = "does not appear to be an IPv4 or IPv6 network"
 ERR_MSG_IP_VERSION_FAILURE = "not a valid IPv4 address"
-ERR_MSG_GRE_TYPE_FAILURE = "not a valid GRE type"
+ERR_MSG_GRE_TYPE_FAILURE = "Wrong gre type format"
 ERR_MSG_VALUE_FAILURE = "Invalid value for"
 
-def test_mirror_session_add():
+ERR_GRE_BROARDCOM_FAILURE = "Only gre type 0x88be and is supported"
+
+@pytest.fixture(scope='module')
+def mock_asic_type():
+    device_info.get_sonic_version_info = mock.MagicMock(return_value = {'asic_type': 'broadcom'})
+
+def test_mirror_session_add(mock_asic_type):
     runner = CliRunner()
 
     # Verify invalid src_ip
     result = runner.invoke(
             config.config.commands["mirror_session"].commands["add"],
-            ["test_session", "400.1.1.1", "2.2.2.2", "8", "63", "10", "100"])
+            ["test_session", "400.1.1.1", "2.2.2.2", "8", "63", "0x88be", "100"])
     assert result.exit_code != 0
     assert ERR_MSG_IP_FAILURE in result.stdout
 
     # Verify invalid dst_ip
     result = runner.invoke(
             config.config.commands["mirror_session"].commands["add"],
-            ["test_session", "1.1.1.1", "256.2.2.2", "8", "63", "10", "100"])
+            ["test_session", "1.1.1.1", "256.2.2.2", "8", "63", "0x88be", "100"])
     assert result.exit_code != 0
     assert ERR_MSG_IP_FAILURE in result.stdout
 
     # Verify invalid ip version
     result = runner.invoke(
             config.config.commands["mirror_session"].commands["add"],
-            ["test_session", "1::1", "2::2", "8", "63", "10", "100"])
+            ["test_session", "1::1", "2::2", "8", "63", "0x88be", "100"])
     assert result.exit_code != 0
     assert ERR_MSG_IP_VERSION_FAILURE in result.stdout
 
     # Verify invalid dscp
     result = runner.invoke(
             config.config.commands["mirror_session"].commands["add"],
-            ["test_session", "1.1.1.1", "2.2.2.2", "65536", "63", "10", "100"])
+            ["test_session", "1.1.1.1", "2.2.2.2", "65536", "63", "0x88be", "100"])
     assert result.exit_code != 0
     assert ERR_MSG_VALUE_FAILURE in result.stdout
 
     # Verify invalid ttl
     result = runner.invoke(
             config.config.commands["mirror_session"].commands["add"],
-            ["test_session", "1.1.1.1", "2.2.2.2", "6", "256", "10", "100"])
+            ["test_session", "1.1.1.1", "2.2.2.2", "6", "256", "0x88be", "100"])
     assert result.exit_code != 0
     assert ERR_MSG_VALUE_FAILURE in result.stdout
 
     # Verify invalid gre
-    result = runner.invoke(
-            config.config.commands["mirror_session"].commands["add"],
-            ["test_session", "1.1.1.1", "2.2.2.2", "6", "63", "65536", "100"])
-    assert result.exit_code != 0
-    assert ERR_MSG_GRE_TYPE_FAILURE in result.stdout
+#     result = runner.invoke(
+#             config.config.commands["mirror_session"].commands["add"],
+#             ["test_session", "1.1.1.1", "2.2.2.2", "6", "63", "65536"])
+#     assert result.exit_code != 0
+#     assert ERR_MSG_VALUE_FAILURE in result.stdout
 
     result = runner.invoke(
             config.config.commands["mirror_session"].commands["add"],
-            ["test_session", "1.1.1.1", "2.2.2.2", "6", "63", "abcd", "100"])
+            ["test_session", "1.1.1.1", "2.2.2.2", "6", "63", "65536", "0"])
+    assert result.exit_code != 0
+    assert ERR_GRE_BROARDCOM_FAILURE in result.stdout
+
+    result = runner.invoke(
+            config.config.commands["mirror_session"].commands["add"],
+            ["test_session", "1.1.1.1", "2.2.2.2", "6", "63", "abcd", "0"])
     assert result.exit_code != 0
     assert ERR_MSG_GRE_TYPE_FAILURE in result.stdout
 
     # Verify invalid queue
     result = runner.invoke(
             config.config.commands["mirror_session"].commands["add"],
-            ["test_session", "1.1.1.1", "2.2.2.2", "6", "63", "65", "65536"])
+            ["test_session", "1.1.1.1", "2.2.2.2", "6", "63", "0x88be", "65536"])
     assert result.exit_code != 0
     assert ERR_MSG_VALUE_FAILURE in result.stdout
 
@@ -74,84 +88,90 @@ def test_mirror_session_add():
     with mock.patch('config.main.add_erspan') as mocked:
         result = runner.invoke(
                 config.config.commands["mirror_session"].commands["add"],
-                ["test_session", "100.1.1.1", "2.2.2.2", "8", "63", "10", "100"])
+                ["test_session", "100.1.1.1", "2.2.2.2", "8", "63", "0x88be", "0"])
 
-        mocked.assert_called_with("test_session", "100.1.1.1", "2.2.2.2", 8, 63, 10, 100, None)
+        mocked.assert_called_with("test_session", "100.1.1.1", "2.2.2.2", 8, 63, "0x88be", 0, None)
 
-        result = runner.invoke(
-                config.config.commands["mirror_session"].commands["add"],
-                ["test_session", "100.1.1.1", "2.2.2.2", "8", "63", "0X1234", "100"])
+        # result = runner.invoke(
+        #         config.config.commands["mirror_session"].commands["add"],
+        #         ["test_session", "100.1.1.1", "2.2.2.2", "8", "63", "0X1234", "100"])
+        #
+        # mocked.assert_called_with("test_session", "100.1.1.1", "2.2.2.2", 8, 63, 0x1234, 100, None)
+        #
+        # result = runner.invoke(
+        #         config.config.commands["mirror_session"].commands["add"],
+        #         ["test_session", "100.1.1.1", "2.2.2.2", "8", "63", "0", "0"])
+        #
+        # mocked.assert_called_with("test_session", "100.1.1.1", "2.2.2.2", 8, 63, 0, 0, None)
+        #
+        # result = runner.invoke(
+        #         config.config.commands["mirror_session"].commands["add"],
+        #         ["test_session", "100.1.1.1", "2.2.2.2", "8", "63"])
+        #
+        # mocked.assert_called_with("test_session", "100.1.1.1", "2.2.2.2", 8, 63, None, None, None)
 
-        mocked.assert_called_with("test_session", "100.1.1.1", "2.2.2.2", 8, 63, 0x1234, 100, None)
 
-        result = runner.invoke(
-                config.config.commands["mirror_session"].commands["add"],
-                ["test_session", "100.1.1.1", "2.2.2.2", "8", "63", "0", "0"])
-
-        mocked.assert_called_with("test_session", "100.1.1.1", "2.2.2.2", 8, 63, 0, 0, None)
-        
-        result = runner.invoke(
-                config.config.commands["mirror_session"].commands["add"],
-                ["test_session", "100.1.1.1", "2.2.2.2", "8", "63"])
-
-        mocked.assert_called_with("test_session", "100.1.1.1", "2.2.2.2", 8, 63, None, None, None)
-
-
-def test_mirror_session_erspan_add():
+def test_mirror_session_erspan_add(mock_asic_type):
     runner = CliRunner()
 
     # Verify invalid src_ip
     result = runner.invoke(
             config.config.commands["mirror_session"].commands["erspan"].commands["add"],
-            ["test_session", "400.1.1.1", "2.2.2.2", "8", "63", "10", "100"])
+            ["test_session", "400.1.1.1", "2.2.2.2", "8", "63", "0x88be"])
     assert result.exit_code != 0
     assert ERR_MSG_IP_FAILURE in result.stdout
 
     # Verify invalid dst_ip
     result = runner.invoke(
             config.config.commands["mirror_session"].commands["erspan"].commands["add"],
-            ["test_session", "1.1.1.1", "256.2.2.2", "8", "63", "10", "100"])
+            ["test_session", "1.1.1.1", "256.2.2.2", "8", "63", "0x88be"])
     assert result.exit_code != 0
     assert ERR_MSG_IP_FAILURE in result.stdout
 
     # Verify invalid ip version
     result = runner.invoke(
             config.config.commands["mirror_session"].commands["erspan"].commands["add"],
-            ["test_session", "1::1", "2::2", "8", "63", "10", "100"])
+            ["test_session", "1::1", "2::2", "8", "63", "0x88be"])
     assert result.exit_code != 0
     assert ERR_MSG_IP_VERSION_FAILURE in result.stdout
 
     # Verify invalid dscp
     result = runner.invoke(
             config.config.commands["mirror_session"].commands["erspan"].commands["add"],
-            ["test_session", "1.1.1.1", "2.2.2.2", "65536", "63", "10", "100"])
+            ["test_session", "1.1.1.1", "2.2.2.2", "65536", "63", "0x88be"])
     assert result.exit_code != 0
     assert ERR_MSG_VALUE_FAILURE in result.stdout
 
     # Verify invalid ttl
     result = runner.invoke(
             config.config.commands["mirror_session"].commands["erspan"].commands["add"],
-            ["test_session", "1.1.1.1", "2.2.2.2", "6", "256", "10", "100"])
+            ["test_session", "1.1.1.1", "2.2.2.2", "6", "256", "0x88be"])
     assert result.exit_code != 0
     assert ERR_MSG_VALUE_FAILURE in result.stdout
 
     # Verify invalid gre
+    # result = runner.invoke(
+    #         config.config.commands["mirror_session"].commands["erspan"].commands["add"],
+    #         ["test_session", "1.1.1.1", "2.2.2.2", "6", "63", "65536"])
+    # assert result.exit_code != 0
+    # assert ERR_MSG_VALUE_FAILURE in result.stdout
+
     result = runner.invoke(
             config.config.commands["mirror_session"].commands["erspan"].commands["add"],
-            ["test_session", "1.1.1.1", "2.2.2.2", "6", "63", "65536", "100"])
+            ["test_session", "1.1.1.1", "2.2.2.2", "6", "63", "65536"])
     assert result.exit_code != 0
-    assert ERR_MSG_GRE_TYPE_FAILURE in result.stdout
-    
+    assert ERR_GRE_BROARDCOM_FAILURE in result.stdout
+
     result = runner.invoke(
             config.config.commands["mirror_session"].commands["erspan"].commands["add"],
-            ["test_session", "1.1.1.1", "2.2.2.2", "6", "63", "abcd", "100"])
+            ["test_session", "1.1.1.1", "2.2.2.2", "6", "63", "abcd", "0"])
     assert result.exit_code != 0
     assert ERR_MSG_GRE_TYPE_FAILURE in result.stdout
 
     # Verify invalid queue
     result = runner.invoke(
             config.config.commands["mirror_session"].commands["erspan"].commands["add"],
-            ["test_session", "1.1.1.1", "2.2.2.2", "6", "63", "65", "65536"])
+            ["test_session", "1.1.1.1", "2.2.2.2", "6", "63", "0x88be", "65536"])
     assert result.exit_code != 0
     assert ERR_MSG_VALUE_FAILURE in result.stdout
 
@@ -159,21 +179,21 @@ def test_mirror_session_erspan_add():
     with mock.patch('config.main.add_erspan') as mocked:
         result = runner.invoke(
                 config.config.commands["mirror_session"].commands["erspan"].commands["add"],
-                ["test_session", "100.1.1.1", "2.2.2.2", "8", "63", "10", "100"])
+                ["test_session", "100.1.1.1", "2.2.2.2", "8", "63", "0x88be", "0"])
 
-        mocked.assert_called_with("test_session", "100.1.1.1", "2.2.2.2", 8, 63, 10, 100, None, None, None)
+        mocked.assert_called_with("test_session", "100.1.1.1", "2.2.2.2", 8, 63, "0x88be", 0, None, None, None)
 
-        result = runner.invoke(
-                config.config.commands["mirror_session"].commands["erspan"].commands["add"],
-                ["test_session", "100.1.1.1", "2.2.2.2", "8", "63", "0x1234", "100"])
-
-        mocked.assert_called_with("test_session", "100.1.1.1", "2.2.2.2", 8, 63, 0x1234, 100, None, None, None)
-
-        result = runner.invoke(
-                config.config.commands["mirror_session"].commands["erspan"].commands["add"],
-                ["test_session", "100.1.1.1", "2.2.2.2", "8", "63", "0", "0"])
-
-        mocked.assert_called_with("test_session", "100.1.1.1", "2.2.2.2", 8, 63, 0, 0, None, None, None)
+        # result = runner.invoke(
+        #         config.config.commands["mirror_session"].commands["erspan"].commands["add"],
+        #         ["test_session", "100.1.1.1", "2.2.2.2", "8", "63", "0x1234", "100"])
+        #
+        # mocked.assert_called_with("test_session", "100.1.1.1", "2.2.2.2", 8, 63, 0x1234, 100, None, None, None)
+        #
+        # result = runner.invoke(
+        #         config.config.commands["mirror_session"].commands["erspan"].commands["add"],
+        #         ["test_session", "100.1.1.1", "2.2.2.2", "8", "63", "0", "0"])
+        #
+        # mocked.assert_called_with("test_session", "100.1.1.1", "2.2.2.2", 8, 63, 0, 0, None, None, None)
 
 
 @patch("validated_config_db_connector.device_info.is_yang_config_validation_enabled", mock.Mock(return_value=True))
@@ -183,7 +203,7 @@ def test_mirror_session_erspan_add_invalid_yang_validation():
     runner = CliRunner()
     result = runner.invoke(
             config.config.commands["mirror_session"].commands["erspan"].commands["add"],
-            ["test_session", "100.1.1.1", "2.2.2.2", "8", "63", "10", "100"])
+            ["test_session", "100.1.1.1", "2.2.2.2", "8", "63", "0x88be", "0"])
     print(result.output)
     assert "Invalid ConfigDB. Error" in result.output
 
@@ -197,7 +217,7 @@ def test_mirror_session_erspan_add_multi_asic_invalid_yang_validation(mock_db_co
     runner = CliRunner()
     result = runner.invoke(
             config.config.commands["mirror_session"].commands["erspan"].commands["add"],
-            ["test_session", "100.1.1.1", "2.2.2.2", "8", "63", "10", "100"])
+            ["test_session", "100.1.1.1", "2.2.2.2", "8", "63", "0x88be", "0"])
     print(result.output)
     assert "Invalid ConfigDB. Error" in result.output
 
@@ -216,28 +236,28 @@ def test_mirror_session_span_add():
     # Verify invalid dst port
     result = runner.invoke(
             config.config.commands["mirror_session"].commands["span"].commands["add"],
-            ["test_session", "Ethern", "Ethernet4", "rx", "100"])
+            ["test_session", "Ethern", "Ethernet4", "rx", "0"])
     assert result.exit_code != 0
     assert "Error: Destination Interface Ethern is invalid" in result.stdout
 
     # Verify destination port not have vlan config
     result = runner.invoke(
             config.config.commands["mirror_session"].commands["span"].commands["add"],
-            ["test_session", "Ethernet24", "Ethernet4", "rx", "100"])
+            ["test_session", "Ethernet24", "Ethernet4", "rx", "0"])
     assert result.exit_code != 0
     assert "Error: Destination Interface Ethernet24 has vlan config" in result.stdout
 
     # Verify destination port is not part of portchannel
     result = runner.invoke(
             config.config.commands["mirror_session"].commands["span"].commands["add"],
-            ["test_session", "Ethernet116", "Ethernet4", "rx", "100"])
+            ["test_session", "Ethernet116", "Ethernet4", "rx", "0"])
     assert result.exit_code != 0
     assert "Error: Destination Interface Ethernet116 has portchannel config" in result.stdout
 
     # Verify destination port not router interface
     result = runner.invoke(
             config.config.commands["mirror_session"].commands["span"].commands["add"],
-            ["test_session", "Ethernet0", "Ethernet4", "rx", "100"])
+            ["test_session", "Ethernet0", "Ethernet4", "rx", "0"])
     assert result.exit_code != 0
     assert "Error: Destination Interface Ethernet0 is a L3 interface" in result.stdout
 
@@ -251,42 +271,42 @@ def test_mirror_session_span_add():
     # Verify source interface is invalid
     result = runner.invoke(
             config.config.commands["mirror_session"].commands["span"].commands["add"],
-            ["test_session", "Ethernet52", "Ethern", "rx", "100"])
+            ["test_session", "Ethernet52", "Ethern", "rx", "0"])
     assert result.exit_code != 0
     assert "Error: Source Interface Ethern is invalid" in result.stdout
 
     # Verify source interface is not same as destination
     result = runner.invoke(
             config.config.commands["mirror_session"].commands["span"].commands["add"],
-            ["test_session", "Ethernet52", "Ethernet52", "rx", "100"])
+            ["test_session", "Ethernet52", "Ethernet52", "rx", "0"])
     assert result.exit_code != 0
     assert "Error: Destination Interface cant be same as Source Interface" in result.stdout
 
     # Verify destination port not have mirror config
     result = runner.invoke(
             config.config.commands["mirror_session"].commands["span"].commands["add"],
-            ["test_session", "Ethernet44", "Ethernet56", "rx", "100"])
+            ["test_session", "Ethernet44", "Ethernet56", "rx", "0"])
     assert result.exit_code != 0
     assert "Error: Destination Interface Ethernet44 already has mirror config" in result.output
 
     # Verify source port is not configured as dstport in other session
     result = runner.invoke(
             config.config.commands["mirror_session"].commands["span"].commands["add"],
-            ["test_session", "Ethernet52", "Ethernet44", "rx", "100"])
+            ["test_session", "Ethernet52", "Ethernet44", "rx", "0"])
     assert result.exit_code != 0
     assert "Error: Source Interface Ethernet44 already has mirror config" in result.output
 
     # Verify source port is not configured in same direction
     result = runner.invoke(
             config.config.commands["mirror_session"].commands["span"].commands["add"],
-            ["test_session", "Ethernet52", "Ethernet8,Ethernet40", "rx", "100"])
+            ["test_session", "Ethernet52", "Ethernet8,Ethernet40", "rx", "0"])
     assert result.exit_code != 0
     assert "Error: Source Interface Ethernet40 already has mirror config in same direction" in result.output
 
     # Verify direction is invalid
     result = runner.invoke(
             config.config.commands["mirror_session"].commands["span"].commands["add"],
-            ["test_session", "Ethernet52", "Ethernet56", "px", "100"])
+            ["test_session", "Ethernet52", "Ethernet56", "px", "0"])
     assert result.exit_code != 0
     assert "Error: Direction px is invalid" in result.stdout
 
@@ -294,9 +314,9 @@ def test_mirror_session_span_add():
     with mock.patch('config.main.add_span') as mocked:
         result = runner.invoke(
                 config.config.commands["mirror_session"].commands["span"].commands["add"],
-                ["test_session", "Ethernet8", "Ethernet4", "tx", "100"])
-        
-        mocked.assert_called_with("test_session", "Ethernet8", "Ethernet4", "tx", 100, None)
+                ["test_session", "Ethernet8", "Ethernet4", "tx", "0"])
+
+        mocked.assert_called_with("test_session", "Ethernet8", "Ethernet4", "tx", 0, None)
 
         result = runner.invoke(
                 config.config.commands["mirror_session"].commands["span"].commands["add"],


### PR DESCRIPTION
#### What I did
* Re-implemented the following two CLI commands to operate synchronously:
  config interface pfc priority <on|off>
  config interface pfc asymmetric <on|off>

* Added support for the pfc-priority-queue command.

#### Why I did it
* In the original implementation, both PFC and PFC asymmetric configurations were applied asynchronously. This meant the CLI did not wait for execution results and always assumed operations succeeded. If the operation failed, the show command output could become inconsistent with the actual hardware state.

* The 202311.X release with ecSAI supports PFC and requires the use of the pfc-priority-queue command

#### How to verify it
Perform 3 test cases:
Case 1: If the config interface pfc priority <interface> <priority> <on|off> command fails, the existing configuration remains unchanged, and the correct error message is displayed.
Case 2: If the config interface pfc asymmetric <interface> <on|off> command fails, the existing configuration remains unchanged, and the correct error message is displayed.
Case 3: Verify that the command pfc-priority-queue is available.

