### PR TITLE
warning messages are showed when executing the “config sflow enable” command.

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -6983,17 +6983,6 @@ def enable(ctx):
     except ValueError as e:
         ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
-    try:
-        proc = subprocess.Popen(['systemctl', 'is-active', 'sflow'], text=True, stdout=subprocess.PIPE)
-        (out, err) = proc.communicate()
-    except SystemExit as e:
-        ctx.fail("Unable to check sflow status {}".format(e))
-
-    if out != "active":
-        log.log_info("sflow service is not enabled. Starting sflow docker...")
-        clicommon.run_command(['sudo', 'systemctl', 'enable', 'sflow'])
-        clicommon.run_command(['sudo', 'systemctl', 'start', 'sflow'])
-
 #
 # 'sflow' command ('config sflow disable')
 #


### PR DESCRIPTION
What I did:
Remove systemctl commands from CLI command 'sudo config sflow enable' because the target sflow.service it wants to control is already managed by CLI command 'sudo config feature state sflow'.

Why I did it:
Fix warning message problem because systemctl detect lack of config in /etc/systemd/system/sflow.service.d/auto_restart.conf when it tries to install sflow.service into system for auto start at system startup.

How I verified it:
Enable sFlow feature and function (no warning message is showed) and verify sFlow sampling packets are able to receive.