### PR TITLE
[sonic-mgmt][mmu] test case, mmu_dynamic_threshold_config_update fix

### DIFF
--- a/generic_config_updater/field_operation_validators.py
+++ b/generic_config_updater/field_operation_validators.py
@@ -77,13 +77,13 @@ def rdma_config_update_validator(patch_element):
     table = jsonpointer.JsonPointer(path).parts[0]
     
     # Helper function to return relevant cleaned paths, considers case where the jsonpatch value is a dict
-    # For paths like /PFC_WD/Ethernet112/action, remove Ethernet112 from the path so that we can clearly determine the relevant field (i.e. action, not Ethernet112)
+    # Remove the index field (if present) after the key.
     def _get_fields_in_patch():
         cleaned_fields = []
 
         field_elements = jsonpointer.JsonPointer(path).parts[1:]
-        cleaned_field_elements = [elem for elem in field_elements if not any(char.isdigit() for char in elem)]
-        cleaned_field = '/'.join(cleaned_field_elements).lower()
+        if len(field_elements) > 0:
+            cleaned_field = '/'.join(field_elements[1:]).lower()
         
 
         if 'value' in patch_element.keys() and isinstance(patch_element['value'], dict):

--- a/generic_config_updater/gcu_field_operation_validators.conf.json
+++ b/generic_config_updater/gcu_field_operation_validators.conf.json
@@ -28,7 +28,12 @@
                 "th": [ "Force10-S6100", "Arista-7060CX-32S-C32", "Arista-7060CX-32S-C32-T1", "Arista-7060CX-32S-D48C8", "Celestica-DX010-C32", "Seastone-DX010" ],
                 "th2": [ "Arista-7260CX3-D108C8",  "Arista-7260CX3-C64", "Arista-7260CX3-Q64" ],
                 "td2": [ "Force10-S6000", "Force10-S6000-Q24S32", "Arista-7050-QX32", "Arista-7050-QX-32S", "Nexus-3164", "Arista-7050QX32S-Q32" ],
-                "td3": [ "Arista-7050CX3-32S-C32", "Arista-7050CX3-32S-D48C8" ]
+                "hr4": [ "Accton-AS4625" ],
+                "hx5": [ "Accton-AS4630" ],
+                "td3": [ "Arista-7050CX3-32S-C32", "Arista-7050CX3-32S-D48C8", "Accton-AS5835", "Accton-AS7326", "Accton-AS7726" ],
+                "td4": [ "Accton-AS9726" ],
+                "th4": [ "Accton-AS9736", "Accton-AS9737" ],
+                "th5": [ "Accton-AS9817" ]
             }
 	}
     },
@@ -104,7 +109,12 @@
                             "td2": "20181100",
                             "th": "20181100",
                             "th2": "20181100",
+                            "hr4": "20231100",
+                            "hx5": "20231100",
                             "td3": "20201200",
+                            "td4": "20231100",
+                            "th4": "20231100",
+                            "th5": "20231100",
                             "cisco-8000": "20201200"
                         }
                     },


### PR DESCRIPTION
What I did:
Added Edgecore switches to the support list in generic-config-updater for the dynamic_th field in BUFFER_PROFILE.

Why I did it:
Previously, generic-config-updater could not apply changes to the dynamic_th field in BUFFER_PROFILE on Edgecore switches due to missing support in the device list.

How I verified it:
Ran the test case and confirmed that it passed successfully.