### PR TITLE
Add cli to show all commands

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -89,6 +89,7 @@ setup(
         'watchdogutil',
         'sonic_cli_gen',
         'wol',
+        'sonic_cli_list',
     ],
     package_data={
         'generic_config_updater': ['gcu_services_validator.conf.json', 'gcu_field_operation_validators.conf.json'],
@@ -224,6 +225,7 @@ setup(
             'watchdogutil = watchdogutil.main:watchdogutil',
             'sonic-cli-gen = sonic_cli_gen.main:cli',
             'wol = wol.main:wol',
+            'sonic-cli-list = sonic_cli_list.main:cli',
         ]
     },
     install_requires=[

--- a/sonic-utilities-data/bash_completion.d/sonic-cli-list
+++ b/sonic-utilities-data/bash_completion.d/sonic-cli-list
@@ -1,0 +1,8 @@
+_sonic_cli_list_completion() {
+    COMPREPLY=( $( env COMP_WORDS="${COMP_WORDS[*]}" \
+                   COMP_CWORD=$COMP_CWORD \
+                   _SONIC_CLI_LIST_COMPLETE=complete $1 ) )
+    return 0
+}
+
+complete -F _sonic_cli_list_completion -o default sonic-cli-list;

--- a/sonic_cli_list/main.py
+++ b/sonic_cli_list/main.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python
+
+import sys
+import click
+import logging
+from show.main import cli as show_main_cli
+from config.main import config
+from clear.main import cli as clear_main_cli
+
+logger = logging.getLogger('sonic-cli-list')
+logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+
+def get_command_group_name(cli_command_group):
+    if hasattr(cli_command_group, 'name') and cli_command_group.name:
+        return cli_command_group.name
+    elif hasattr(cli_command_group, '__name__'):
+        return cli_command_group.__name__
+    elif hasattr(cli_command_group, '__class__'):
+        return cli_command_group.__class__.__name__
+    else:
+        return "unknown commands"
+
+def extract_click_commands_info(group, parent_name=''):
+    commands_info = {}
+    command_group_name = get_command_group_name(group)
+    for name, command in group.commands.items():
+        if parent_name is not None:
+            full_name = f"{parent_name} {name}".strip()
+        else:
+            full_name = f"{parent_name} {name}".strip()
+        commands_info[full_name] = {
+            'arguments': [],
+            'options': []
+        }
+
+        for param in command.params:
+            if isinstance(param, click.Argument):
+                arg_info = {
+                    'name': param.name,
+                    'choices': None
+                }
+                if isinstance(param.type, click.Choice):
+                    arg_info['choices'] = param.type.choices
+                commands_info[full_name]['arguments'].append(arg_info)
+
+            elif isinstance(param, click.Option):
+                opt_info = {
+                    'opts': param.opts,
+                    'choices': None
+                }
+                if isinstance(param.type, click.Choice):
+                    opt_info['choices'] = param.type.choices
+                commands_info[full_name]['options'].append(opt_info)
+
+        if isinstance(command, click.core.Group):
+            commands_info.update(extract_click_commands_info(command, full_name))
+
+    return commands_info
+
+def print_commands_info(commands_info, title, print_type="all"):
+    sorted_commands = sorted(commands_info.items(), key=lambda x: x[0])
+
+    for command, info in sorted_commands:
+        command_str = f"{title} {command}"
+
+        arg_strs = []
+        for arg in info['arguments']:
+            arg_desc = f"argument: {arg['name']}"
+            if arg['choices']:
+                arg_desc += f" (Choices: {', '.join(arg['choices'])})"
+            arg_strs.append(arg_desc)
+        arg_str = " ".join(arg_strs) if arg_strs else "argument: None"
+
+        opt_strs = []
+        for opt in info['options']:
+            opt_desc = f"option: {', '.join(opt['opts'])}"
+            if opt['choices']:
+                opt_desc += f" (Choices: {', '.join(opt['choices'])})"
+            opt_strs.append(opt_desc)
+        opt_str = " ".join(opt_strs) if opt_strs else "option: None"
+
+        if print_type == "all":
+            print(f"{command_str} [{arg_str}] [{opt_str}]")
+        elif print_type == "argument":
+            print(f"{command_str} [{arg_str}]")
+        else:
+            print(f"{command_str} [{opt_str}]")
+
+@click.group()
+@click.pass_context
+def cli(ctx):
+    pass
+
+@cli.command()
+@click.argument('print_type', default='all', type=click.Choice(['argument', 'option', 'all'], case_sensitive=False))
+@click.pass_context
+def show(ctx, print_type):
+    show_main_commands_info = extract_click_commands_info(show_main_cli)
+    print("Show Main Commands Info:")
+    print_commands_info(show_main_commands_info, "show", print_type)
+
+    config_main_commands_info = extract_click_commands_info(config)
+    print("\nConfig Main Commands Info:")
+    print_commands_info(config_main_commands_info, "config", print_type)
+
+    clear_main_commands_info = extract_click_commands_info(clear_main_cli)
+    print("\nClear Main Commands Info:")
+    print_commands_info(clear_main_commands_info, "clear", print_type)
+
+
+if __name__ == '__main__':
+    cli()


### PR DESCRIPTION
Only print command and argument information
- sonic-cli-list show argument Only print command and option information
- sonic-cli-list show option Print all information
- sonic-cli-list show all

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

