### PR TITLE
Restart dhcp relay when enabled dhcpv6 relay and sag

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -40,6 +40,8 @@ from .validated_config_db_connector import ValidatedConfigDBConnector
 import utilities_common.asic_info as asic_info
 import utilities_common.multi_asic as multi_asic_util
 import utilities_common.config_util as config_util
+import utilities_common.dhcp_relay_util as dhcp_relay_util
+import utilities_common.dhcp_relay_util as is_dhcp_relay_running
 
 
 from .utils import log
@@ -7791,6 +7793,9 @@ def add_mac(db, mac_address):
         click.get_current_context().fail(f'static-anycast-gateway MAC address {mac_address} is multicast, only allow unicast.')
 
     if not db.cfgdb.get_entry('SAG', 'GLOBAL'):
+        if is_dhcpv6_relay_config_with_sag(db):
+            if dhcp_relay_util.is_dhcp_relay_running():
+                dhcp_relay_util.handle_restart_dhcp_relay_service()
         db.cfgdb.set_entry('SAG', 'GLOBAL', {'gateway_mac': mac_address})
     else:
         click.get_current_context().fail(f'static-anycast-gateway MAC address {mac_address} is alreday existed. Remove it first')
@@ -7803,10 +7808,24 @@ def del_mac(db):
 
     sag_entry = db.cfgdb.get_entry('SAG', 'GLOBAL')
     if sag_entry:
+        if is_dhcpv6_relay_config_with_sag(db):
+            if dhcp_relay_util.is_dhcp_relay_running():
+                dhcp_relay_util.handle_restart_dhcp_relay_service()
         db.cfgdb.mod_entry('SAG', 'GLOBAL', None)
     else:
         click.get_current_context().fail(f'static-anycast-gateway MAC address {mac_address} not found.')
 
+def is_dhcpv6_relay_config_with_sag(db):
+    DHCP_RELAY_TABLE = "DHCP_RELAY"
+    VLAN_INTERFACE_TABLE = "VLAN_INTERFACE"
+    relay_keys = db.cfgdb.get_keys(DHCP_RELAY_TABLE)
+    vlan_intf_keys = db.cfgdb.get_keys(VLAN_INTERFACE_TABLE)
+    for key in relay_keys:
+        if key.startswith('Vlan') and key in vlan_intf_keys:
+            vlan_intf_entry = db.cfgdb.get_entry('VLAN_INTERFACE', key)
+            if vlan_intf_entry.get("static_anycast_gateway") == "true":
+                return True
+    return False
 
 
 from . import acl as acl_command

--- a/config/vlan.py
+++ b/config/vlan.py
@@ -369,6 +369,9 @@ def enable_vlan_sag(db, vid):
         if k == vlan and v.get('unique_ip') == 'enable':
             ctx.fail("MCLAG unique-ip is enabled. Remove it first.")
 
+    if is_dhcpv6_relay_config_exist(db, vlan):
+        if is_dhcp_relay_running() and is_sag_mac_config_exist(db):
+            dhcp_relay_util.handle_restart_dhcp_relay_service()
     db.cfgdb.mod_entry('VLAN_INTERFACE', vlan, {"static_anycast_gateway": "true"})
 
 
@@ -387,7 +390,15 @@ def disable_vlan_sag(db, vid):
 
     current_entry = db.cfgdb.get_entry('VLAN_INTERFACE', vlan)
     if current_entry.get("static_anycast_gateway") == "true":
+        if is_dhcpv6_relay_config_exist(db, vlan):
+            if is_dhcp_relay_running() and is_sag_mac_config_exist(db):
+                dhcp_relay_util.handle_restart_dhcp_relay_service()
         db.cfgdb.mod_entry('VLAN_INTERFACE', vlan, {"static_anycast_gateway": "false"})
     else:
         ctx.fail(f"static-anycast-gateway is already disabled")
 
+def is_sag_mac_config_exist(db):
+    sag_entry = db.cfgdb.get_entry('SAG', 'GLOBAL')
+    if sag_entry:
+        return True
+    return False

--- a/utilities_common/dhcp_relay_util.py
+++ b/utilities_common/dhcp_relay_util.py
@@ -18,3 +18,8 @@ def handle_restart_dhcp_relay_service():
     except SystemExit as e:
         ctx = click.get_current_context()
         ctx.fail("Restart service dhcp_relay failed with error {}".format(e))
+
+def is_dhcp_relay_running():
+    out, _ = clicommon.run_command(["systemctl", "show", "dhcp_relay.service", "--property", "ActiveState", "--value"],
+                                   return_cmd=True)
+    return out.strip() == "active"


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fixed an issue with the incorrect IPv6 link-local address when enabling both DHCPv6 relay and static anycast gateway (SAG).

#### How I did it
The DHCP relay service is restarted when enabling DHCPv6 relay and SAG simultaneously.
There are two types of commands that need to be considered:
* sudo config vlan static-anycast-gateway enable 1000
* sudo config static-anycast-gateway mac_address add 00:11:22:33:44:ff

#### How to verify it
Case 1: Run sudo config static-anycast-gateway mac_address add 00:11:22:33:44:ff first
1.Configure DHCPv6 relay.
2.Run sudo config static-anycast-gateway mac_address add 00:11:22:33:44:ff.
3.Run sudo config vlan static-anycast-gateway enable 1000 and verify that the container restarts.
3.Run sudo config vlan static-anycast-gateway disable 1000 and verify that the container restarts.

Case 2: Run sudo config vlan static-anycast-gateway enable 1000 first
1.Configure DHCPv6 relay.
2.Run sudo config vlan static-anycast-gateway enable 1000.
3.Run sudo config static-anycast-gateway mac_address add 00:11:22:33:44:ff and verify that the container restarts.
4.Run sudo config static-anycast-gateway mac_address del and verify that the container restarts.

#### Previous command output (if the output of a command-line utility has changed)
None
#### New command output (if the output of a command-line utility has changed)
None
