### PR TITLE
[route_check] Optimize route_check by reducing ASIC-DB subscriptions …

### DIFF
--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -13,11 +13,8 @@ How:
     1) Initiate subscribe for ASIC-DB updates.
     2) Read APPL-DB & ASIC-DB
     3) Get the diff.
-    4) If any diff,
-        4.1) Collect subscribe messages for a second
-        4.2) check diff against the subscribe messages
-    5) Rule out local interfaces & default routes
-    6) If still outstanding diffs, report failure.
+    4) Rule out local interfaces & default routes
+    5) If still outstanding diffs, report failure.
 
 To verify:
     Run this tool in SONiC switch and watch the result. In case of failure
@@ -52,10 +49,9 @@ from utilities_common import chassis
 
 APPL_DB_NAME = 'APPL_DB'
 ASIC_DB_NAME = 'ASIC_DB'
-ASIC_TABLE_NAME = 'ASIC_STATE'
-ASIC_KEY_PREFIX = 'SAI_OBJECT_TYPE_ROUTE_ENTRY:'
+ASIC_TABLE_NAME = 'ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY'
 
-SUBSCRIBE_WAIT_SECS = 1
+COOLING_TIME = 0
 
 # Max of 2 minutes
 TIMEOUT_SECONDS = 120
@@ -230,48 +226,16 @@ def diff_sorted_lists(t1, t2):
     return t1_miss, t2_miss
 
 
-def checkout_rt_entry(k):
+def extract_normalize_ip(key):
     """
-    helper to filter out correct keys and strip out IP alone.
-    :param ip: key to check as string
+    Extracts and normalizes an IP address from the key if it is not local.
+    :param key: key to check as string
     :return (True, ip) or (False, None)
     """
-    if k.startswith(ASIC_KEY_PREFIX):
-        e = k.lower().split("\"", -1)[3]
-        if not is_local(e):
-            return True, normalize_ip_network(e)
+    ip_str = key.lower().split("\"", -1)[3]
+    if not is_local(ip_str):
+        return True, normalize_ip_network(ip_str)
     return False, None
-
-
-def get_subscribe_updates(selector, subs):
-    """
-    helper to collect subscribe messages for a period
-    :param selector: Selector object to wait
-    :param subs: Subscription object to pop messages
-    :return (add, del) messages as sorted
-    """
-    adds = []
-    deletes = []
-    t_end = time.time() + SUBSCRIBE_WAIT_SECS
-    t_wait = SUBSCRIBE_WAIT_SECS
-
-    while t_wait > 0:
-        selector.select(t_wait)
-        t_wait = int(t_end - time.time())
-        while True:
-            key, op, val = subs.pop()
-            if not key:
-                break
-            res, e = checkout_rt_entry(key)
-            if res:
-                if op == "SET":
-                    adds.append(e)
-                elif op == "DEL":
-                    deletes.append(e)
-
-    print_message(syslog.LOG_DEBUG, "adds={}".format(adds))
-    print_message(syslog.LOG_DEBUG, "dels={}".format(deletes))
-    return (sorted(adds), sorted(deletes))
 
 
 def is_vrf(k):
@@ -302,28 +266,23 @@ def get_routes():
 
 def get_route_entries():
     """
-    helper to read present route entries from ASIC-DB and
-    as well initiate selector for ASIC-DB:ASIC-state updates.
-    :return (selector,  subscriber, <list of sorted routes>)
+    helper to read present route entries from ASIC-DB.
+    :return list of sorted routes
     """
     db = swsscommon.DBConnector(ASIC_DB_NAME, 0)
-    subs = swsscommon.SubscriberStateTable(db, ASIC_TABLE_NAME)
-    print_message(syslog.LOG_DEBUG, "ASIC DB connected")
+    print_message(syslog.LOG_DEBUG, "ASIC DB connected for ROUTE_ENTRY")
+    tbl = swsscommon.Table(db, ASIC_TABLE_NAME)
+    keys = tbl.getKeys()
 
     rt = []
-    while True:
-        k, _, _ = subs.pop()
-        if not k:
-            break
-        res, e = checkout_rt_entry(k)
+    for key in keys:
+        res, e = extract_normalize_ip(key)
         if res:
             rt.append(e)
 
-    print_message(syslog.LOG_DEBUG, json.dumps({"ASIC_ROUTE_ENTRY": sorted(rt)}, indent=4))
-
-    selector = swsscommon.Select()
-    selector.addSelectable(subs)
-    return (selector, subs, sorted(rt))
+    sorted_route = sorted(rt)
+    print_message(syslog.LOG_DEBUG, json.dumps({"ASIC_ROUTE_ENTRY": sorted_route}, indent=4))
+    return sorted_route
 
 
 def get_interfaces():
@@ -611,10 +570,8 @@ def check_routes():
     rt_asic_miss = []
 
     results = {}
-    adds = []
-    deletes = []
 
-    selector, subs, rt_asic = get_route_entries()
+    rt_asic = get_route_entries()
 
     rt_appl = get_routes()
     intf_appl = get_interfaces()
@@ -643,15 +600,9 @@ def check_routes():
     if rt_appl_miss or rt_asic_miss:
         rt_appl_miss, rt_asic_miss = filter_out_vlan_neigh_route_miss(rt_appl_miss, rt_asic_miss)
 
-    if rt_appl_miss or rt_asic_miss:
-        # Look for subscribe updates for a second
-        adds, deletes = get_subscribe_updates(selector, subs)
-
-        # Drop all those for which SET received
-        rt_appl_miss, _ = diff_sorted_lists(rt_appl_miss, adds)
-
-        # Drop all those for which DEL received
-        rt_asic_miss, _ = diff_sorted_lists(rt_asic_miss, deletes)
+    # FIXME: This is a workaround for the test_timeout issue,
+    # as route_check runs so quickly that the timer doesn't have time to interrupt.
+    time.sleep(COOLING_TIME)
 
     if rt_appl_miss:
         results["missed_ROUTE_TABLE_routes"] = rt_appl_miss
@@ -665,8 +616,6 @@ def check_routes():
     if results:
         print_message(syslog.LOG_WARNING, "Failure results: {",  json.dumps(results, indent=4), "}")
         print_message(syslog.LOG_WARNING, "Failed. Look at reported mismatches above")
-        print_message(syslog.LOG_WARNING, "add: ", json.dumps(adds, indent=4))
-        print_message(syslog.LOG_WARNING, "del: ", json.dumps(deletes, indent=4))
         return -1, results
     else:
         print_message(syslog.LOG_INFO, "All good!")

--- a/tests/route_check_test.py
+++ b/tests/route_check_test.py
@@ -191,23 +191,6 @@ class mock_subscriber:
         return self.tbl
 
 
-def subscriber_side_effect(db, tbl):
-    global subscribers_returned
-
-    key = "db_{}_tbl_{}".format(db, tbl)
-    if not key in subscribers_returned:
-        subscribers_returned[key] = mock_subscriber(db, tbl)
-    return subscribers_returned[key]
-
-
-def select_side_effect():
-    global selector_returned
-
-    if not selector_returned:
-        selector_returned = mock_selector()
-    return selector_returned
-
-
 def table_side_effect(db, tbl):
     if not db in tables_returned:
         tables_returned[db] = {}
@@ -226,11 +209,9 @@ def config_db_side_effect(table):
     return tables_returned[CONFIG_DB][table]
 
 
-def set_mock(mock_table, mock_conn, mock_sel, mock_subs, mock_config_db):
+def set_mock(mock_table, mock_conn, mock_config_db):
     mock_conn.side_effect = conn_side_effect
     mock_table.side_effect = table_side_effect
-    mock_sel.side_effect = select_side_effect
-    mock_subs.side_effect = subscriber_side_effect
     mock_config_db.get_table = MagicMock(side_effect=config_db_side_effect)
 
 class TestRouteCheck(object):
@@ -243,12 +224,15 @@ class TestRouteCheck(object):
     @pytest.fixture
     def force_hang(self):
         old_timeout = route_check.TIMEOUT_SECONDS
+        old_coolingtime = route_check.COOLING_TIME
         route_check.TIMEOUT_SECONDS = 5
+        route_check.COOLING_TIME = 10
         mock_selector.EMULATE_HANG = True
 
         yield
 
         route_check.TIMEOUT_SECONDS = old_timeout
+        route_check.COOLING_TIME = old_coolingtime
         mock_selector.EMULATE_HANG = False
 
     @pytest.fixture
@@ -256,11 +240,9 @@ class TestRouteCheck(object):
         mock_config_db = MagicMock()
         with patch("route_check.swsscommon.DBConnector") as mock_conn, \
              patch("route_check.swsscommon.Table") as mock_table, \
-             patch("route_check.swsscommon.Select") as mock_sel, \
-             patch("route_check.swsscommon.SubscriberStateTable") as mock_subs, \
              patch("route_check.swsscommon.ConfigDBConnector", return_value=mock_config_db):
             device_info.get_platform = MagicMock(return_value='unittest')
-            set_mock(mock_table, mock_conn, mock_sel, mock_subs, mock_config_db)
+            set_mock(mock_table, mock_conn, mock_config_db)
             yield
 
     @pytest.mark.parametrize("test_num", TEST_DATA.keys())

--- a/tests/route_check_test_data.py
+++ b/tests/route_check_test_data.py
@@ -15,14 +15,14 @@ NEIGH_TABLE = 'NEIGH_TABLE'
 ROUTE_TABLE = 'ROUTE_TABLE'
 VNET_ROUTE_TABLE = 'VNET_ROUTE_TABLE'
 INTF_TABLE = 'INTF_TABLE'
-RT_ENTRY_TABLE = 'ASIC_STATE'
+RT_ENTRY_TABLE = 'ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY'
 SEPARATOR = ":"
 DEVICE_METADATA = "DEVICE_METADATA"
 MUX_CABLE = "MUX_CABLE"
 
 LOCALHOST = "localhost"
 
-RT_ENTRY_KEY_PREFIX = 'SAI_OBJECT_TYPE_ROUTE_ENTRY:{\"dest":\"'
+RT_ENTRY_KEY_PREFIX = ':{\"dest\":\"'
 RT_ENTRY_KEY_SUFFIX = '\",\"switch_id\":\"oid:0x21000000000000\",\"vr\":\"oid:0x3000000000023\"}'
 
 DEFAULT_CONFIG_DB = {DEVICE_METADATA: {LOCALHOST: {}}}
@@ -57,45 +57,6 @@ TEST_DATA = {
         }
     },
     "1": {
-        DESCR: "With updates",
-        ARGS: "route_check -m DEBUG -i 1",
-        PRE: {
-            APPL_DB: {
-                ROUTE_TABLE: {
-                    "0.0.0.0/0" : { "ifname": "portchannel0" },
-                    "10.10.196.12/31" : { "ifname": "portchannel0" },
-                    "10.10.196.20/31" : { "ifname": "portchannel0" },
-                    "10.10.196.30/31" : { "ifname": "lo" }
-                },
-                INTF_TABLE: {
-                    "PortChannel1013:10.10.196.24/31": {},
-                    "PortChannel1023:2603:10b0:503:df4::5d/126": {}
-                }
-            },
-            ASIC_DB: {
-                RT_ENTRY_TABLE: {
-                    RT_ENTRY_KEY_PREFIX + "10.10.196.20/31" + RT_ENTRY_KEY_SUFFIX: {},
-                    RT_ENTRY_KEY_PREFIX + "10.10.196.24/32" + RT_ENTRY_KEY_SUFFIX: {},
-                    RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df4::5d/128" + RT_ENTRY_KEY_SUFFIX: {},
-                    RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + RT_ENTRY_KEY_SUFFIX: {},
-                    RT_ENTRY_KEY_PREFIX + "10.10.10.10/32" + RT_ENTRY_KEY_SUFFIX: {}
-                }
-            }
-        },
-        UPD: {
-            ASIC_DB: {
-                RT_ENTRY_TABLE: {
-                    OP_SET: {
-                        RT_ENTRY_KEY_PREFIX + "10.10.196.12/31" + RT_ENTRY_KEY_SUFFIX: {},
-                    },
-                    OP_DEL: {
-                        RT_ENTRY_KEY_PREFIX + "10.10.10.10/32" + RT_ENTRY_KEY_SUFFIX: {}
-                    }
-                }
-            }
-        }
-    },
-    "2": {
         DESCR: "basic failure one",
         ARGS: "route_check -i 15",
         RET: -1,
@@ -140,7 +101,7 @@ TEST_DATA = {
             ]
         }
     },
-    "3": {
+    "2": {
         DESCR: "basic good one with no args",
         ARGS: "route_check",
         PRE: {
@@ -168,7 +129,7 @@ TEST_DATA = {
             }
         }
     },
-    "4": {
+    "3": {
         DESCR: "Good one with routes on voq inband interface",
         ARGS: "route_check",
         PRE: {
@@ -206,7 +167,7 @@ TEST_DATA = {
             }
         }
     },
-    "5": {
+    "4": {
         DESCR: "local route with nexthop - fail",
         ARGS: "route_check -m INFO -i 1000",
         RET: -1,
@@ -240,7 +201,7 @@ TEST_DATA = {
             ]
         }
     },
-    "6": {
+    "5": {
         DESCR: "Good one with VNET routes",
         ARGS: "route_check",
         PRE: {
@@ -279,7 +240,7 @@ TEST_DATA = {
             }
         }
     },
-    "7": {
+    "6": {
         DESCR: "dualtor standalone tunnel route case",
         ARGS: "route_check",
         PRE: {
@@ -300,7 +261,7 @@ TEST_DATA = {
             }
         }
     },
-    "8": {
+    "7": {
         DESCR: "Good one with VRF routes",
         ARGS: "route_check",
         PRE: {
@@ -327,7 +288,7 @@ TEST_DATA = {
             }
         }
     },
-    "9": {
+    "8": {
         DESCR: "SOC IPs on Libra ToRs should be ignored",
         ARGS: "route_check",
         PRE: {
@@ -362,7 +323,7 @@ TEST_DATA = {
             }
         }
     },
-    "11": {
+    "9": {
         DESCR: "dualtor ignore vlan neighbor route miss case",
         ARGS: "route_check -i 15",
         RET: -1,
@@ -416,7 +377,7 @@ TEST_DATA = {
             ]
         }
     },
-    "12": {
+    "10": {
         DESCR: "IPv4 mapped IPv6 address route check",
         ARGS: "route_check",
         PRE: {


### PR DESCRIPTION
#### What I did
1.  On low-performance CPUs, large ROUTE_ENTRY executions caused system hangs due to excessive SubscriberStateTable subscriptions to ASIC_STATE TABLE, which also led to prolonged route_check execution (>120s) and crashes triggered by monit termination (>300s).
2. Unnecessary synchronization checks between APPL-DB and ASIC-DB were redundant, as route_check only requires ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY subscriptions.

#### How I did it
1. Canceled redundant subscription checks and TEST_DATA 1 to prevent system hangs.
3. Modified ASIC_TABLE_NAME in route_check.py and route_check_test_data.py to subscribe only to ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY, reducing subscription overhead.
4. Refactored checkout_rt_entry to extract_normalize_ip for clearer IP extraction logic, enhancing route_check efficiency.

#### How to verify it
1. https://accton-group.atlassian.net/browse/SONIC-12057
2. https://accton-group.atlassian.net/browse/JRTC-25817

