### PR TITLE
Add Xsight patch for X2

### DIFF
--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -793,7 +793,7 @@ class AclLoader(object):
                 except AclLoaderException as ex:
                     error("Error processing rule %s: %s. Skipped." % (acl_entry_name, ex))
 
-            if not self.is_table_mirror(table_name):
+            if not self.is_table_egress(table_name):
                 deep_update(self.rules_info, self.deny_rule(table_name))
 
     def full_update(self):


### PR DESCRIPTION
- Fix condition check in AclLoader to use is_table_egress instead of is_table_mirror for table validation

What I did
- Add Xsight patch for X2 testing

Why I did it
- Add Xsight patch for X2 testing
