### PR TITLE
QoS template files were not being applied on the Xsight ES9618xx device.

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -267,7 +267,7 @@ def breakout_Ports(cm, delPorts=list(), portJson=dict(), force=False, \
 def is_community_brcm_sai():
     # The Broadcom SAI package name can be determined from the installed image
     # directory (/host/image-<image-version>), if it exists.
-    command = "find /host/image-`docker images | grep syncd-brcm | grep -v latest | awk '{print $2}'` -name \"*libsaibcm*\" | grep -e \"libsaibcm$\""
+    command = "find /host/image-`docker images | grep syncd-brcm | grep -v latest | awk '{print $2}'` -name \"*libsaibcm*\" 2>/dev/null | grep -e \"libsaibcm$\""
     proc = subprocess.Popen(command, shell=True)
     proc.communicate()
 


### PR DESCRIPTION
What I did:
The original implementation applied QoS template files only when running
with ecSAI. The condition was updated to apply the QoS template files by
default, except when running with the community Broadcom SAI. As a
result, the Xsight ES9618xx device is now able to load the QoS templates
as well.

Why I did it:
The lack of QoS template files on the Xsight ES9618xx caused failures in
the pfc_config and ecn_config_update test cases.