### PR TITLE
[EVPN] fdbshow: Fix key type handling for SAI_FDB_ENTRY_ATTR_ENDPOINT_IP

### DIFF
--- a/scripts/fdbshow
+++ b/scripts/fdbshow
@@ -100,10 +100,10 @@ class FdbShow(object):
             br_port_id = ent["SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID"][oid_pfx:]
             ent_type = ent["SAI_FDB_ENTRY_ATTR_TYPE"]
             fdb_type = ['Dynamic','Static'][ent_type == "SAI_FDB_ENTRY_TYPE_STATIC"]
-            if br_port_id not in self.if_br_oid_map and b"SAI_FDB_ENTRY_ATTR_ENDPOINT_IP" not in ent:
+            if br_port_id not in self.if_br_oid_map and "SAI_FDB_ENTRY_ATTR_ENDPOINT_IP" not in ent:
                 continue
-            if b"SAI_FDB_ENTRY_ATTR_ENDPOINT_IP" in ent and ent[b"SAI_FDB_ENTRY_ATTR_ENDPOINT_IP"]!='0.0.0.0':
-                if_name = "VxLAN DIP: %s" %(ent[b"SAI_FDB_ENTRY_ATTR_ENDPOINT_IP"])
+            if "SAI_FDB_ENTRY_ATTR_ENDPOINT_IP" in ent and ent["SAI_FDB_ENTRY_ATTR_ENDPOINT_IP"]!='0.0.0.0':
+                if_name = "VxLAN DIP: %s" %(ent["SAI_FDB_ENTRY_ATTR_ENDPOINT_IP"])
             else:
                 port_id = self.if_br_oid_map[br_port_id]
                 if port_id in self.if_oid_map:


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Refactored fdbshow to remove incorrect use of byte string literals (e.g., b"SAI_FDB_ENTRY_ATTR_ENDPOINT_IP") when accessing FDB entry attributes.

Ensured consistent use of standard string keys when checking for "SAI_FDB_ENTRY_ATTR_ENDPOINT_IP" and retrieving its value.

This change resolves issues where entries with SAI_FDB_ENTRY_ATTR_ENDPOINT_IP were incorrectly skipped or displayed due to key mismatch.


