### PR TITLE
To fix the stp clear cli syntax error

### DIFF
--- a/clear/stp.py
+++ b/clear/stp.py
@@ -17,7 +17,7 @@ def spanning_tree(ctx):
 @click.pass_context
 def stp_clr_stats(ctx):
     if ctx.invoked_subcommand is None:
-        command = 'sudo stpctl clrstsall'
+        command = ['sudo', 'stpctl', 'clrstsall']
         clicommon.run_command(command)
 
 
@@ -25,7 +25,7 @@ def stp_clr_stats(ctx):
 @click.argument('interface_name', metavar='<interface_name>', required=True)
 @click.pass_context
 def stp_clr_stats_intf(ctx, interface_name):
-    command = 'sudo stpctl clrstsintf ' + interface_name
+    command = ['sudo', 'stpctl', 'clrstsintf', '{}'.format(interface_name)] 
     clicommon.run_command(command)
 
 
@@ -33,7 +33,7 @@ def stp_clr_stats_intf(ctx, interface_name):
 @click.argument('vlan_id', metavar='<vlan_id>', required=True)
 @click.pass_context
 def stp_clr_stats_vlan(ctx, vlan_id):
-    command = 'sudo stpctl clrstsvlan ' + vlan_id
+    command = ['sudo', 'stpctl', 'clrstsvlan', '{}'.format(vlan_id)]
     clicommon.run_command(command)
 
 
@@ -42,5 +42,5 @@ def stp_clr_stats_vlan(ctx, vlan_id):
 @click.argument('interface_name', metavar='<interface_name>', required=True)
 @click.pass_context
 def stp_clr_stats_vlan_intf(ctx, vlan_id, interface_name):
-    command = 'sudo stpctl clrstsvlanintf ' + vlan_id + ' ' + interface_name
+    command = ['sudo', 'stpctl', 'clrstsvlanintf', '{}'.format(vlan_id), '{}'.format(interface_name)]
     clicommon.run_command(command)


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
The command syntax was modified to resolve the STP clear CLI error.
#### How I did it

#### How to verify it
```
admin@as9726-32d-1:~$ sudo sonic-clear spanning-tree statistics
All stats cleared
admin@as9726-32d-1:~$ sudo sonic-clear spanning-tree statistics interface Ethernet0
Stats cleared for Ethernet0
admin@as9726-32d-1:~$ sudo sonic-clear spanning-tree statistics vlan 1000
Stats cleared for VLAN 1000
admin@as9726-32d-1:~$ sudo sonic-clear spanning-tree statistics vlan-interface 1000 Ethernet8
Stats cleared for VLAN 1000 Ethernet8
```
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

