### PR TITLE
[nbrshow] Prevent crash when FDB entries are missing or aged out

### DIFF
--- a/scripts/nbrshow
+++ b/scripts/nbrshow
@@ -81,7 +81,14 @@ class NbrBase(object):
             if not fdb:
                 continue
 
-            ent = self.db.get_all('ASIC_DB', s, blocking=True)
+            try:
+                ent = self.db.get_all('ASIC_DB', s, blocking=False)
+            except:
+                continue
+
+            if "SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID" not in ent:
+                continue
+
             br_port_id = ent["SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID"][oid_pfx:]
             if br_port_id not in self.if_br_oid_map:
                 continue


### PR DESCRIPTION
#### Why I did it
When excessive MAC addresses are learned and MAC aging occurs, pre-fetched keys may become out of sync with the actual ASIC_DB state, causing nbrshow or show arp to terminate unexpectedly.

#### What I did
Disable blocking on get_all() to avoid repeated retries. Add try-except to prevent nbrshow termination on database access failure. Add checks for required keys in FDB entries to avoid KeyError.

#### How I verified it
Run nbrshow -4/-6 or show arp on DUT with many MACs and aging events: command completes successfully. Problematic FDB entries are skipped; valid neighbors are displayed. ARP/neighbor pytest tests pass.