### PR TITLE
Support dynamic_th field in BUFFER_PROFILE for new devices AS9716/AS7712/AS7816

### DIFF
--- a/generic_config_updater/gcu_field_operation_validators.conf.json
+++ b/generic_config_updater/gcu_field_operation_validators.conf.json
@@ -25,13 +25,14 @@
                 "spc4": [ "ACS-SN5600"]
             },
             "broadcom_asics": {
-                "th": [ "Force10-S6100", "Arista-7060CX-32S-C32", "Arista-7060CX-32S-C32-T1", "Arista-7060CX-32S-D48C8", "Celestica-DX010-C32", "Seastone-DX010" ],
-                "th2": [ "Arista-7260CX3-D108C8",  "Arista-7260CX3-C64", "Arista-7260CX3-Q64" ],
+                "th": [ "Force10-S6100", "Arista-7060CX-32S-C32", "Arista-7060CX-32S-C32-T1", "Arista-7060CX-32S-D48C8", "Celestica-DX010-C32", "Seastone-DX010", "Accton-AS7712" ],
+                "th2": [ "Arista-7260CX3-D108C8",  "Arista-7260CX3-C64", "Arista-7260CX3-Q64", "Accton-AS7816" ],
                 "td2": [ "Force10-S6000", "Force10-S6000-Q24S32", "Arista-7050-QX32", "Arista-7050-QX-32S", "Nexus-3164", "Arista-7050QX32S-Q32" ],
                 "hr4": [ "Accton-AS4625" ],
                 "hx5": [ "Accton-AS4630" ],
                 "td3": [ "Arista-7050CX3-32S-C32", "Arista-7050CX3-32S-D48C8", "Accton-AS5835", "Accton-AS7326", "Accton-AS7726" ],
                 "td4": [ "Accton-AS9726" ],
+                "th3": [ "Accton-AS9716" ],
                 "th4": [ "Accton-AS9736", "Accton-AS9737" ],
                 "th5": [ "Accton-AS9817" ]
             }
@@ -113,6 +114,7 @@
                             "hx5": "20231100",
                             "td3": "20201200",
                             "td4": "20231100",
+                            "th3": "20231100",
                             "th4": "20231100",
                             "th5": "20231100",
                             "cisco-8000": "20201200"


### PR DESCRIPTION
What I did:
Added Edgecore switches to the support list in generic-config-updater for the dynamic_th field in BUFFER_PROFILE.

Why I did it:
Previously, generic-config-updater could not apply changes to the dynamic_th field in BUFFER_PROFILE on Edgecore switches due to missing support in the device list.