### PR TITLE
JIRA-SONIC-13386: Adopting Barefoot's implementation due to Xisght's lack of support for independent WRED/ECN configuration.

### DIFF
--- a/config/wred.py
+++ b/config/wred.py
@@ -597,7 +597,7 @@ def add_command(config, interface):
         config.add_command(wred)
 
         version_info = device_info.get_sonic_version_info()
-        if version_info and version_info.get('asic_type', '') == 'barefoot':
+        if version_info and version_info.get('asic_type', '') in ('barefoot', 'xsight'):
             wred.add_command(add_bfn)
             wred.add_command(update_bfn)
         else:


### PR DESCRIPTION
#### What I did
We are adopting the Barefoot method because WRED and ECN cannot be configured separately on the Xisght platform.


#### How to verify it
Using the CLI configure the ECN profile on Xsight platform, the ECN feature is worked.
