### PR TITLE
Fix the version of m2crypto (0.38).

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -243,7 +243,7 @@ setup(
         'jsondiff>=1.2.0',
         'jsonpatch>=1.32.0',
         'jsonpointer>=1.9',
-        'm2crypto>=0.31.0',
+        'm2crypto==0.38.0',
         'natsort>=6.2.1',  # 6.2.1 is the last version which supports Python 2. Can update once we no longer support Python 2
         'netaddr>=0.8.0',
         'netifaces>=0.10.7',


### PR DESCRIPTION
#### What I did
Fix the version of m2crypto (0.38).

#### Why I did
The requirement will use the latest version (0.47) of M2Crypto, which requires OpenSSL 3.0. However, Sonic only uses OpenSSL 1.1. Therefore, the image build will be built.