### PR TITLE
[SONiC build issue] Fix the version of m2crypto (0.38).

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -243,7 +243,7 @@ setup(
         'jsondiff>=1.2.0',
         'jsonpatch>=1.32.0',
         'jsonpointer>=1.9',
-        'm2crypto>=0.31.0',
+        'm2crypto==0.38.0',
         'natsort>=6.2.1',  # 6.2.1 is the last version which supports Python 2. Can update once we no longer support Python 2
         'netaddr>=0.8.0',
         'netifaces>=0.10.7',


### PR DESCRIPTION
- What I did: Fix the version of m2crypto (0.38).

- Why I did: The requirement will use the latest version (0.47) of M2Crypto, which requires OpenSSL 3.0. However, Sonic only uses OpenSSL 1.1. Therefore, the image build will be built.

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

